### PR TITLE
feat: typed action cards and a self-hosted approval surface

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+name: "🐍 Python Tests"
+
+# A gate that can actually fail.
+#
+# agent-ci.yml's auto-detect job never runs this suite: it checks for
+# package.json before the Python branch, and MyXstack has one (the TypeScript
+# agent in src/), so it classifies this repo as "node". Its Python step is
+# also `pytest ... 2>/dev/null || true` under continue-on-error, so it could
+# not fail even if it were reached. This job exists to close that gap and is
+# deliberately free of `|| true`, `2>/dev/null`, and continue-on-error.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # Matches the Dockerfile (python:3.12-slim), which is what ships.
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dist/
 
 # Data stores (created at runtime)
 *.json.bak
+*.json.lock
+*.json.tmp
 ~/.xmcp/
 
 # OS

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY *.py .
 COPY openapi.json .
+COPY agents/ ./agents/
+# Approval surface served by timeline_server at /ui
+COPY ui/ ./ui/
 
 # Default command (overridden per service in docker-compose)
 CMD ["sh", "-lc", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ run:
 	@sleep 2
 	. .venv/bin/activate && python listener.py &
 	. .venv/bin/activate && python mcp_dispatcher.py &
-	@echo "\n✅ All services running. Use 'make stop' to shut down."
+	@echo "\n✅ All services running. Approval UI: http://localhost:8080/ui"
+	@echo "   Use 'make stop' to shut down."
 
 stop:
 	@pkill -f "python server.py" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ runs at import time, so it applies to every entrypoint including
 `timeline_server.main()`. Set `TIMELINE_ALLOW_INSECURE=1` to override
 deliberately. Without a deployment marker, an empty token only warns.
 
+**That detection is a heuristic with a known gap.** Only Railway and
+Kubernetes are recognised. A VPS, Fly, Render, or `docker compose` on a public
+host sets none of those markers, so an empty token there warns rather than
+refusing — and the approval API is reachable anonymously. Set
+`TIMELINE_API_TOKEN` yourself on any host not in that list. Closing the gap
+means inverting the default (always fatal, opt out explicitly for local),
+which is a deliberate open question rather than an oversight.
+
 ```bash
 export TIMELINE_API_TOKEN="$(openssl rand -hex 32)"   # export: make run needs it in the child env
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There is also an alternative **TypeScript standalone agent** in `src/` that comb
 
 ## Prerequisites
 
-- **Python 3.11+** (for the service stack)
+- **Python 3.12** (for the service stack — matches the Dockerfile and CI)
 - **X API credentials** — [developer.x.com/portal](https://developer.x.com/portal) (Basic tier minimum)
 - **xAI API key** — [console.x.ai](https://console.x.ai/) (for Grok)
 - **Node.js 20+** (only if using the TypeScript agent)
@@ -131,24 +131,44 @@ labels. An `action_id` the card doesn't offer is rejected with a 400.
 The timeline server serves a dependency-free approval surface at
 **http://localhost:8080/ui**. It lists cards, renders their typed content, and
 sends approvals back to the API. Enter the API token (if one is set) in the
-header; it is kept in `localStorage`, never in the served file.
+header.
 
 Cards whose action has already been executed render disabled, mirroring the
 dispatcher's rule that a processed card is terminal.
+
+> **Token storage.** The UI keeps the token in `localStorage` so a reload
+> doesn't lose it. That is a deliberate convenience for an operator console on
+> a trusted machine, not a hardened default: any same-origin script, and anyone
+> with access to the browser profile, can read it. Treat the token as a
+> credential that lives on that machine, rotate it when a browser profile is
+> shared or retired, and prefer a dedicated browser profile for the console.
 
 ### Authentication
 
 The timeline and A2A API — including the PATCH that authorizes agent actions —
 is **unauthenticated when `TIMELINE_API_TOKEN` is empty**, which keeps local
-development frictionless. The server prints a warning at startup in that state.
-Set the token before exposing the service anywhere:
+development frictionless.
+
+**On a deployment, an empty token is fatal rather than merely noisy.** When a
+deployment marker is present (`RAILWAY_SERVICE_NAME`, `RAILWAY_ENVIRONMENT`,
+`KUBERNETES_SERVICE_HOST`) and no token is set, the app refuses to start. This
+runs at import time, so it applies to every entrypoint including
+`uvicorn main:app` — the Railway path, which never calls
+`timeline_server.main()`. Set `TIMELINE_ALLOW_INSECURE=1` to override
+deliberately. Without a deployment marker, an empty token only warns.
 
 ```bash
-TIMELINE_API_TOKEN=$(openssl rand -hex 32)
+export TIMELINE_API_TOKEN="$(openssl rand -hex 32)"   # export: make run needs it in the child env
 ```
 
-All four services read the same value. `/health` never requires it.
-Set `TIMELINE_CORS_ORIGINS` only if you host a surface on another origin.
+All four services must read the same value. Under `docker compose` that happens
+via the shared `env_file`, but **separate Railway services do not inherit each
+other's environment** — set `TIMELINE_API_TOKEN` on the timeline-server,
+listener, and dispatcher services individually, or the workers will get 401s.
+
+`/health` never requires the token, so container and load-balancer probes keep
+working. Set `TIMELINE_CORS_ORIGINS` only if you host a surface on another
+origin.
 
 ## Card Content
 
@@ -160,10 +180,12 @@ blob of text. Four block types cover what members produce:
 | `text` | A prose section (`label` becomes its heading) |
 | `facts` | Key/value pairs — the parameters of a proposed action |
 | `table` | Tabular results |
-| `links` | Sources or destinations |
+| `links` | Sources or destinations (http/https only — other schemes are rejected) |
 
-Actions are typed too — `{id, label, style, confirm}` — where `label` is both
-what the human reads and what a member's `execute_action` matches on.
+Actions are typed too — `{id, label, style}` plus an optional `confirm` prompt —
+where `label` is both what the human reads and what a member's `execute_action`
+matches on. Action ids must be unique within a card; duplicates are rejected
+with a 422.
 
 Members build cards with helpers from `agents/base.py` rather than raw dicts:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ curl http://localhost:8080/v1/a2a/agents
 | PATCH | `/v1/timeline/items/{id}` | Update / take action on card |
 | DELETE | `/v1/timeline/items/{id}` | Delete card |
 
+Take an action with either `{"action_id": "approve"}` (what the UI sends) or
+`{"action": "Approve"}` (the label). Both dispatch identically — the server
+resolves an id to its label before handing off, because team members match on
+labels. An `action_id` the card doesn't offer is rejected with a 400.
+
 ### Agent-to-Agent (A2A)
 
 | Method | Endpoint | Description |
@@ -120,6 +125,65 @@ curl http://localhost:8080/v1/a2a/agents
 | POST | `/v1/a2a/agents` | Register new agent |
 | GET | `/v1/a2a/agents/{id}/messages` | Get agent's messages |
 | POST | `/v1/a2a/messages` | Send agent message |
+
+## Approval UI
+
+The timeline server serves a dependency-free approval surface at
+**http://localhost:8080/ui**. It lists cards, renders their typed content, and
+sends approvals back to the API. Enter the API token (if one is set) in the
+header; it is kept in `localStorage`, never in the served file.
+
+Cards whose action has already been executed render disabled, mirroring the
+dispatcher's rule that a processed card is terminal.
+
+### Authentication
+
+The timeline and A2A API — including the PATCH that authorizes agent actions —
+is **unauthenticated when `TIMELINE_API_TOKEN` is empty**, which keeps local
+development frictionless. The server prints a warning at startup in that state.
+Set the token before exposing the service anywhere:
+
+```bash
+TIMELINE_API_TOKEN=$(openssl rand -hex 32)
+```
+
+All four services read the same value. `/health` never requires it.
+Set `TIMELINE_CORS_ORIGINS` only if you host a surface on another origin.
+
+## Card Content
+
+A card carries typed `blocks` so a surface can render structure instead of one
+blob of text. Four block types cover what members produce:
+
+| Block | Use |
+|-------|-----|
+| `text` | A prose section (`label` becomes its heading) |
+| `facts` | Key/value pairs — the parameters of a proposed action |
+| `table` | Tabular results |
+| `links` | Sources or destinations |
+
+Actions are typed too — `{id, label, style, confirm}` — where `label` is both
+what the human reads and what a member's `execute_action` matches on.
+
+Members build cards with helpers from `agents/base.py` rather than raw dicts:
+
+```python
+from agents.base import build_card, facts_block, text_block, approve_reject
+
+card = build_card(
+    title="Trade proposal: BUY 10 $TSLA",
+    blocks=[
+        facts_block({"Ticker": "$TSLA", "Side": "BUY"}, label="Order"),
+        text_block(mention.text, label="Requested via X"),
+    ],
+    actions=approve_reject("Approve", "Reject"),
+    metadata={"agent_id": "tradedesk", "action_type": "trade"},
+)
+```
+
+**Backward compatibility.** `body` is still populated — derived from `blocks`
+when not supplied — so anything reading it keeps working. Cards written before
+typed blocks are upgraded in memory on read; there is no on-disk migration.
 
 ## OpenAPI Filtering
 
@@ -181,8 +245,11 @@ Timeline cards and A2A messages are stored in JSON files at `~/.xmcp/` by defaul
 ├── timeline_server.py     # Timeline + A2A FastAPI server
 ├── listener.py            # X mention poller + Grok responder
 ├── mcp_dispatcher.py      # Timeline action executor
+├── cards.py               # Typed card schema (blocks, actions, legacy upgrade)
 ├── timeline_store.py      # JSON-file timeline persistence
 ├── a2a_store.py           # JSON-file A2A persistence
+├── store_lock.py          # Cross-process file locking for the JSON stores
+├── ui/                    # Approval surface served at /ui (no build step)
 ├── openapi.json           # X API OpenAPI spec (used by MCP server)
 ├── src/                   # TypeScript standalone agent (alternative)
 ├── docs/                  # Architecture, deployment, usage guides

--- a/a2a_store.py
+++ b/a2a_store.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import insert, select, update
+from sqlalchemy.exc import IntegrityError
 
 from storage_db import (
     a2a_agents,
@@ -81,21 +82,32 @@ def _ensure_default_agents() -> None:
         if _SEEDED_ENGINE is engine:
             return
 
-        with write_connection() as conn:
+        with read_connection() as conn:
             existing_ids = {
                 row[0]
                 for row in conn.execute(select(a2a_agents.c.id).where(a2a_agents.c.id.in_([a["id"] for a in DEFAULT_AGENTS])))
             }
 
-            for agent in DEFAULT_AGENTS:
-                if agent["id"] in existing_ids:
-                    continue
-                conn.execute(
-                    insert(a2a_agents).values(
-                        **agent,
-                        created_at=utc_now(),
+        for agent in DEFAULT_AGENTS:
+            if agent["id"] in existing_ids:
+                continue
+            # _SEED_LOCK only covers threads in this process, and every service
+            # seeds on boot against the same database. On SQLite the writers
+            # serialize, but Postgres runs this at READ COMMITTED, so the check
+            # above can be stale by the time the insert lands. Losing that race
+            # means another service already created the agent, which is the
+            # desired end state -- so each insert stands alone (an error would
+            # otherwise poison a shared transaction) and a duplicate is fine.
+            try:
+                with write_connection() as conn:
+                    conn.execute(
+                        insert(a2a_agents).values(
+                            **agent,
+                            created_at=utc_now(),
+                        )
                     )
-                )
+            except IntegrityError:
+                pass
 
         _SEEDED_ENGINE = engine
 

--- a/a2a_store.py
+++ b/a2a_store.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import insert, select, update
+from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from storage_db import (
@@ -107,7 +108,17 @@ def _ensure_default_agents() -> None:
                         )
                     )
             except IntegrityError:
-                pass
+                # IntegrityError covers every constraint, not just the primary
+                # key collision this tolerates. Confirm the desired end state
+                # actually holds -- otherwise a NOT NULL or check violation
+                # would be swallowed here and _SEEDED_ENGINE set below, so the
+                # agent stays missing and no error is ever raised.
+                with read_connection() as check:
+                    present = check.execute(
+                        select(a2a_agents.c.id).where(a2a_agents.c.id == agent["id"])
+                    ).fetchone()
+                if not present:
+                    raise
 
         _SEEDED_ENGINE = engine
 
@@ -172,7 +183,12 @@ def list_messages(agent_id: str) -> List[Dict[str, Any]]:
     return [_serialize_message(row_to_dict(row)) for row in rows]
 
 
-def add_message(payload: Dict[str, Any]) -> Dict[str, Any]:
+def add_message(payload: Dict[str, Any], *, conn: Optional[Connection] = None) -> Dict[str, Any]:
+    """Record an A2A message.
+
+    Pass `conn` to enlist in a caller's transaction. The approval path does,
+    so that claiming a card and recording the dispatch it authorises land
+    together or not at all."""
     message = {
         "id": payload.get("id") or str(uuid.uuid4()),
         "from_agent": payload.get("from", "system"),
@@ -182,6 +198,10 @@ def add_message(payload: Dict[str, Any]) -> Dict[str, Any]:
         "metadata": payload.get("metadata", {}),
         "created_at": utc_now(),
     }
-    with write_connection() as conn:
-        conn.execute(insert(a2a_messages).values(**message))
+    statement = insert(a2a_messages).values(**message)
+    if conn is not None:
+        conn.execute(statement)
+    else:
+        with write_connection() as own_conn:
+            own_conn.execute(statement)
     return _serialize_message(message)

--- a/a2a_store.py
+++ b/a2a_store.py
@@ -1,13 +1,13 @@
 import json
 import os
-import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from store_lock import file_lock
+
 A2A_STORE_PATH = Path(os.getenv("A2A_STORE_PATH", "~/.xmcp/a2a_store.json")).expanduser()
-A2A_STORE_LOCK = threading.Lock()
 
 DEFAULT_AGENTS = [
     {
@@ -64,17 +64,20 @@ def _read_store() -> Dict[str, Any]:
 
 
 def _write_store(data: Dict[str, Any]) -> None:
+    """Atomic replace so a mid-write crash can't truncate the store."""
     A2A_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    A2A_STORE_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp = A2A_STORE_PATH.with_suffix(A2A_STORE_PATH.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.replace(tmp, A2A_STORE_PATH)
 
 
 def list_agents() -> List[Dict[str, Any]]:
-    with A2A_STORE_LOCK:
+    with file_lock(A2A_STORE_PATH):
         return _read_store()["agents"]
 
 
 def get_agent(agent_id: str) -> Optional[Dict[str, Any]]:
-    with A2A_STORE_LOCK:
+    with file_lock(A2A_STORE_PATH):
         for agent in _read_store()["agents"]:
             if agent.get("id") == agent_id:
                 return agent
@@ -95,7 +98,7 @@ def register_agent(payload: Dict[str, Any]) -> Dict[str, Any]:
         "tags": payload.get("tags", []),
         "created_at": _utc_now(),
     }
-    with A2A_STORE_LOCK:
+    with file_lock(A2A_STORE_PATH):
         data = _read_store()
         for existing in data["agents"]:
             if existing.get("id") == agent["id"]:
@@ -111,7 +114,7 @@ def register_agent(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def list_messages(agent_id: str) -> List[Dict[str, Any]]:
-    with A2A_STORE_LOCK:
+    with file_lock(A2A_STORE_PATH):
         data = _read_store()
         return [msg for msg in data["messages"] if msg.get("to") == agent_id]
 
@@ -126,7 +129,7 @@ def add_message(payload: Dict[str, Any]) -> Dict[str, Any]:
         "metadata": payload.get("metadata", {}),
         "created_at": _utc_now(),
     }
-    with A2A_STORE_LOCK:
+    with file_lock(A2A_STORE_PATH):
         data = _read_store()
         data["messages"].insert(0, message)
         _write_store(data)

--- a/agents/base.py
+++ b/agents/base.py
@@ -96,6 +96,90 @@ def truncate_for_reply(
     return prefix + suffix
 
 
+def text_block(text: str, label: Optional[str] = None) -> Dict[str, Any]:
+    """A prose section of a card."""
+    return {"type": "text", "label": label, "text": text}
+
+
+def facts_block(
+    facts: Dict[str, Any] | List[Dict[str, str]], label: Optional[str] = None
+) -> Dict[str, Any]:
+    """Key/value pairs — typically the parameters of a proposed action.
+
+    Accepts a plain dict for convenience; values are stringified because a
+    card is a presentation artifact, not a typed payload (the machine-
+    readable copy belongs in card metadata)."""
+    if isinstance(facts, dict):
+        pairs = [{"key": str(k), "value": str(v)} for k, v in facts.items()]
+    else:
+        pairs = [{"key": str(f["key"]), "value": str(f["value"])} for f in facts]
+    return {"type": "facts", "label": label, "facts": pairs}
+
+
+def table_block(
+    columns: List[str], rows: List[List[Any]], label: Optional[str] = None
+) -> Dict[str, Any]:
+    """Tabular results, e.g. product picks or ticker rows."""
+    return {
+        "type": "table",
+        "label": label,
+        "columns": [str(c) for c in columns],
+        "rows": [[str(cell) for cell in row] for row in rows],
+    }
+
+
+def links_block(
+    links: List[Dict[str, str]], label: Optional[str] = None
+) -> Dict[str, Any]:
+    """A list of sources or destinations."""
+    return {
+        "type": "links",
+        "label": label,
+        "links": [{"label": str(l["label"]), "url": str(l["url"])} for l in links],
+    }
+
+
+def approve_reject(
+    approve_label: str = "Approve", reject_label: str = "Reject"
+) -> List[Dict[str, Any]]:
+    """The standard two-button approval gate.
+
+    The labels are what execute_action() implementations match on, so
+    overriding them is a behavioural change — keep a member's labels and
+    its matching in sync."""
+    return [
+        {"id": "approve", "label": approve_label, "style": "primary"},
+        {"id": "reject", "label": reject_label, "style": "danger"},
+    ]
+
+
+def build_card(
+    title: str,
+    blocks: List[Dict[str, Any]],
+    actions: Optional[List[Dict[str, Any]]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Assemble a timeline card.
+
+    metadata should carry agent_id so the dispatcher can route an approval
+    back to the member that proposed it."""
+    return {
+        "title": title,
+        "blocks": blocks,
+        "actions": actions or [],
+        "metadata": metadata or {},
+    }
+
+
+def timeline_headers() -> Dict[str, str]:
+    """Auth header for internal calls to the timeline/A2A API.
+
+    Empty when TIMELINE_API_TOKEN is unset, which keeps local development
+    working against an unauthenticated server."""
+    token = os.getenv("TIMELINE_API_TOKEN", "").strip()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
 def grok_chat(prompt: str) -> str:
     """One-shot Grok call with MCP tools (same wiring as the listener)."""
     api_key = os.getenv("XAI_API_KEY", "").strip()
@@ -142,6 +226,7 @@ def send_a2a_message(
                 "content": content,
                 "metadata": metadata or {},
             },
+            headers=timeline_headers(),
             timeout=10,
         )
         # requests doesn't raise on 4xx/5xx; a rejected message is a failure.

--- a/agents/base.py
+++ b/agents/base.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from cards import is_safe_url
+
 KIND_AGENT = "agent"
 KIND_BOT = "bot"
 
@@ -131,12 +133,19 @@ def table_block(
 def links_block(
     links: List[Dict[str, str]], label: Optional[str] = None
 ) -> Dict[str, Any]:
-    """A list of sources or destinations."""
-    return {
-        "type": "links",
-        "label": label,
-        "links": [{"label": str(l["label"]), "url": str(l["url"])} for l in links],
-    }
+    """A list of sources or destinations.
+
+    Non-http(s) URLs are dropped here rather than passed along: card content
+    is derived from model output over untrusted mentions, and the approval
+    surface renders these into an anchor's href."""
+    safe = []
+    for link in links:
+        url = str(link["url"])
+        if not is_safe_url(url):
+            print(f"Dropping unsafe card link URL: {url!r}", flush=True)
+            continue
+        safe.append({"label": str(link["label"]), "url": url})
+    return {"type": "links", "label": label, "links": safe}
 
 
 def approve_reject(

--- a/agents/broker.py
+++ b/agents/broker.py
@@ -7,33 +7,12 @@ by replacing PaperBroker with an adapter exposing the same interface.
 
 import json
 import os
-import threading
 import uuid
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-_LEDGER_LOCK = threading.Lock()
-
-
-@contextmanager
-def _ledger_file_lock(ledger_path: Path):
-    """Cross-process advisory lock so concurrent dispatchers can't corrupt
-    the ledger (fcntl is Unix-only; degrades to the thread lock elsewhere)."""
-    ledger_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        import fcntl
-    except ImportError:
-        yield
-        return
-    lock_file = ledger_path.with_suffix(".lock")
-    with open(lock_file, "w") as handle:
-        fcntl.flock(handle, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(handle, fcntl.LOCK_UN)
+from store_lock import file_lock
 
 
 class PaperBroker:
@@ -72,7 +51,7 @@ class PaperBroker:
         with the same key already exists, it is returned with
         duplicate=True instead of booking a second fill.
         """
-        with _LEDGER_LOCK, _ledger_file_lock(self.ledger_path):
+        with file_lock(self.ledger_path):
             fills = self._read()
             if key:
                 for existing in fills:
@@ -96,7 +75,7 @@ class PaperBroker:
         totals: Dict[str, float] = {}
         # Same locks as execute(): _read()'s corrupt-ledger recovery renames
         # the file, which must not race a writer in another process.
-        with _LEDGER_LOCK, _ledger_file_lock(self.ledger_path):
+        with file_lock(self.ledger_path):
             fills = self._read()
         for fill in fills:
             sign = 1 if fill.get("side") == "buy" else -1

--- a/agents/registry.py
+++ b/agents/registry.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 import requests
 
-from agents.base import MentionContext, TeamMember
+from agents.base import MentionContext, TeamMember, timeline_headers
 from agents.router import find_target
 
 
@@ -73,7 +73,10 @@ def register_team() -> None:
         for attempt in range(3):
             try:
                 response = requests.post(
-                    f"{timeline_url}/v1/a2a/agents", json=payload, timeout=10
+                    f"{timeline_url}/v1/a2a/agents",
+                    json=payload,
+                    headers=timeline_headers(),
+                    timeout=10,
                 )
                 # 4xx/5xx (e.g. server still booting) must retry too.
                 response.raise_for_status()

--- a/agents/team/research.py
+++ b/agents/team/research.py
@@ -14,7 +14,9 @@ from agents.base import (
     AgentReply,
     MentionContext,
     TeamMember,
+    build_card,
     grok_chat,
+    text_block,
     truncate_for_reply,
     wrap_untrusted,
 )
@@ -43,14 +45,16 @@ class ResearchAgent(TeamMember):
             return AgentReply(text="Research agent is offline (no XAI_API_KEY configured).")
 
         reply = truncate_for_reply(brief, suffix="… Full brief on your timeline.")
-        card = {
-            "title": "Research brief",
-            "body": f"Question:\n{mention.text}\n\nBrief:\n{brief}",
-            "actions": [],
-            "metadata": {
+        card = build_card(
+            title="Research brief",
+            blocks=[
+                text_block(mention.text, label="Question"),
+                text_block(brief, label="Brief"),
+            ],
+            metadata={
                 "agent_id": self.profile.id,
                 "action_type": "research",
                 "mention_id": mention.mention_id,
             },
-        }
+        )
         return AgentReply(text=reply, card=card)

--- a/agents/team/shopping.py
+++ b/agents/team/shopping.py
@@ -17,7 +17,10 @@ from agents.base import (
     AgentReply,
     MentionContext,
     TeamMember,
+    approve_reject,
+    build_card,
     grok_chat,
+    text_block,
     truncate_for_reply,
     wrap_untrusted,
 )
@@ -50,17 +53,22 @@ class ShoppingAgent(TeamMember):
         if not picks:
             return AgentReply(text="Shopping agent is offline (no XAI_API_KEY configured).")
 
-        card = {
-            "title": "Shopping picks",
-            "body": f"Request:\n{mention.text}\n\nPicks:\n{picks}",
-            "actions": ["Approve Purchase", "Reject"],
-            "metadata": {
+        card = build_card(
+            title="Shopping picks",
+            blocks=[
+                text_block(mention.text, label="Request"),
+                text_block(picks, label="Picks"),
+            ],
+            # Labels must stay in sync with execute_action() below, which
+            # matches on them rather than on the action id.
+            actions=approve_reject("Approve Purchase", "Reject"),
+            metadata={
                 "agent_id": self.profile.id,
                 "action_type": "purchase",
                 "mention_id": mention.mention_id,
                 "author_id": mention.author_id,
             },
-        }
+        )
         reply = truncate_for_reply(picks, suffix="… Full list on your timeline.")
         return AgentReply(text=reply, card=card)
 

--- a/agents/team/tradedesk.py
+++ b/agents/team/tradedesk.py
@@ -19,7 +19,11 @@ from agents.base import (
     AgentReply,
     MentionContext,
     TeamMember,
+    approve_reject,
+    build_card,
+    facts_block,
     grok_chat,
+    text_block,
 )
 from agents.broker import PaperBroker
 
@@ -82,15 +86,30 @@ class TradeDeskAgent(TeamMember):
                 f"relevant to a proposed {trade['side']} order. Facts only, no advice."
             )
 
-        body = f"Requested via X mention {mention.mention_id or '?'}:\n\n{mention.text}"
+        blocks = [
+            facts_block(
+                {
+                    "Ticker": f"${trade['ticker']}",
+                    "Side": trade["side"].upper(),
+                    "Quantity": f"{trade['quantity']:g}",
+                    "Venue": "paper (simulated)",
+                },
+                label="Order",
+            ),
+            text_block(
+                mention.text,
+                label=f"Requested via X mention {mention.mention_id or '?'}",
+            ),
+        ]
         if context:
-            body += f"\n\nMarket context (Grok):\n{context}"
+            blocks.append(text_block(context, label="Market context (Grok)"))
 
-        card = {
-            "title": f"Trade proposal: {summary}",
-            "body": body,
-            "actions": ["Approve", "Reject"],
-            "metadata": {
+        card = build_card(
+            title=f"Trade proposal: {summary}",
+            blocks=blocks,
+            # execute_action() below matches these labels exactly.
+            actions=approve_reject("Approve", "Reject"),
+            metadata={
                 "agent_id": self.profile.id,
                 "action_type": "trade",
                 "ticker": trade["ticker"],
@@ -99,7 +118,7 @@ class TradeDeskAgent(TeamMember):
                 "mention_id": mention.mention_id,
                 "author_id": mention.author_id,
             },
-        }
+        )
         reply = (
             f"📋 Trade proposal logged: {summary}. Pending human approval on the "
             f"timeline. (Paper trading — no live orders.)"

--- a/cards.py
+++ b/cards.py
@@ -270,13 +270,22 @@ def normalize_card(item: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
 def resolve_action(item: Optional[Dict[str, Any]], action_id: str) -> Optional[str]:
     """Map an action id back to the label team members match on.
 
-    Returns None when the card has no such action — the caller must treat
+    Returns None when the card has no such action -- the caller must treat
     that as a rejected request rather than inventing a label, or a surface
-    could trigger an action the card never offered."""
-    card = normalize_card(item)
-    if not card:
+    could trigger an action the card never offered.
+
+    Also returns None when the id is ambiguous. Reads stay lenient about
+    duplicate ids so one bad historical record cannot make a timeline
+    unreadable, but "lenient" must stop at the dispatch boundary: picking the
+    first match would execute a different action than the human selected, and
+    silently. Unresolvable is the safe answer -- the API turns it into a 400
+    and nothing is claimed or dispatched.
+    """
+    if item is None:
         return None
-    for action in card.get("actions") or []:
-        if action.get("id") == action_id:
-            return action.get("label")
-    return None
+    matches = [
+        action.get("label")
+        for action in normalize_actions(item.get("actions"))
+        if action.get("id") == action_id
+    ]
+    return matches[0] if len(matches) == 1 else None

--- a/cards.py
+++ b/cards.py
@@ -31,12 +31,31 @@ is no on-disk migration.
 
 import re
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 SCHEMA_VERSION = 2
 
 BLOCK_TYPES = ("text", "facts", "table", "links")
+
+# Only these schemes may reach an anchor's href. Anything else — javascript:,
+# data:, vbscript: — executes in the approval surface's origin.
+SAFE_URL_SCHEMES = ("http", "https")
+
+
+def is_safe_url(value: Any) -> bool:
+    """True when `value` is an http(s) URL safe to render as a link.
+
+    Shared by the Link model, the agents/base.py builder, and (mirrored) the
+    browser renderer, so all three agree on what a renderable URL is."""
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = urlparse(value.strip())
+    except ValueError:
+        return False
+    return parsed.scheme.lower() in SAFE_URL_SCHEMES and bool(parsed.netloc)
 
 
 # --------------------------------------------------------------------------
@@ -50,8 +69,24 @@ class Fact(BaseModel):
 
 
 class Link(BaseModel):
+    """A labelled hyperlink.
+
+    `url` is restricted to http(s). Card content originates from model output
+    over untrusted X mentions and is rendered into an anchor's href, so a
+    `javascript:` or `data:` URL would execute in the approval surface's
+    origin — where the bearer token that authorizes agent actions lives."""
+
     label: str
     url: str
+
+    @field_validator("url")
+    @classmethod
+    def _safe_scheme(cls, value: str) -> str:
+        if not is_safe_url(value):
+            raise ValueError(
+                f"unsupported URL scheme in {value!r}: only http and https are allowed"
+            )
+        return value
 
 
 class TextBlock(BaseModel):
@@ -162,9 +197,21 @@ def derive_body(blocks: List[Dict[str, Any]]) -> str:
     return "\n\n".join(_render_block(b) for b in blocks if b)
 
 
-def normalize_actions(actions: Any) -> List[Dict[str, Any]]:
+class DuplicateActionIdError(ValueError):
+    """Raised when a card offers two actions with the same id.
+
+    `resolve_action` returns the first match, so duplicate ids would make a
+    surface dispatch a different action than the human selected, and leave
+    the later button permanently unreachable."""
+
+
+def normalize_actions(actions: Any, *, strict: bool = False) -> List[Dict[str, Any]]:
     """Coerce either legacy `["Approve", "Reject"]` or typed action dicts
-    into a uniform list of action dicts."""
+    into a uniform list of action dicts.
+
+    strict=True rejects duplicate ids — used when accepting a new card at
+    the API boundary. Reads of already-stored cards stay lenient so one bad
+    historical record can't make the whole timeline unreadable."""
     if not isinstance(actions, list):
         return []
 
@@ -184,6 +231,18 @@ def normalize_actions(actions: Any) -> List[Dict[str, Any]]:
                     "confirm": action.get("confirm"),
                 }
             )
+
+    if strict:
+        seen = set()
+        for action in normalized:
+            action_id = action["id"]
+            if action_id in seen:
+                raise DuplicateActionIdError(
+                    f"duplicate action id {action_id!r}: each action on a card "
+                    "must be addressable on its own"
+                )
+            seen.add(action_id)
+
     return normalized
 
 

--- a/cards.py
+++ b/cards.py
@@ -1,0 +1,223 @@
+"""Typed timeline cards.
+
+A timeline card is how a team member asks a human to look at something —
+and, when the card carries actions, to authorize something. Before this
+module a card's entire presentation contract was `body: str` plus
+`actions: List[str]`, so every member hand-concatenated its output into
+one blob and no surface could render structure.
+
+A card now carries `blocks`: a small closed set of content types that
+covers what members actually produce (prose sections, key/value facts,
+tabular results, link lists). The set is deliberately small — a surface
+must be able to render every block type, so growing it is a real cost.
+
+Two compatibility rules keep older readers working, and both are
+load-bearing:
+
+1. `body` is never dropped. When a card is written with `blocks`, `body`
+   is populated with `derive_body(blocks)`. Anything that reads `body`
+   today — the dispatcher, existing tests, plain curl — keeps working.
+
+2. `action` on the wire keeps carrying the human *label*, not the id.
+   Team members match on labels (`agents/team/shopping.py` matches
+   `startswith("approve")` against "Approve Purchase";
+   `agents/team/tradedesk.py` matches `== "approve"`). A surface posts
+   `action_id` and the server resolves it back to the label via
+   `resolve_action` before dispatching, so member code is untouched.
+
+Legacy records are upgraded in memory on read by `normalize_card`; there
+is no on-disk migration.
+"""
+
+import re
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+SCHEMA_VERSION = 2
+
+BLOCK_TYPES = ("text", "facts", "table", "links")
+
+
+# --------------------------------------------------------------------------
+# Models (used by the API layer for validation)
+# --------------------------------------------------------------------------
+
+
+class Fact(BaseModel):
+    key: str
+    value: str
+
+
+class Link(BaseModel):
+    label: str
+    url: str
+
+
+class TextBlock(BaseModel):
+    """A prose section, e.g. label="Brief" for a research write-up."""
+
+    type: Literal["text"] = "text"
+    label: Optional[str] = None
+    text: str
+
+
+class FactsBlock(BaseModel):
+    """Key/value pairs — the parameters of a proposed action."""
+
+    type: Literal["facts"] = "facts"
+    label: Optional[str] = None
+    facts: List[Fact] = Field(default_factory=list)
+
+
+class TableBlock(BaseModel):
+    """Tabular results, e.g. product picks or ticker rows."""
+
+    type: Literal["table"] = "table"
+    label: Optional[str] = None
+    columns: List[str] = Field(default_factory=list)
+    rows: List[List[str]] = Field(default_factory=list)
+
+
+class LinksBlock(BaseModel):
+    """A list of sources or destinations."""
+
+    type: Literal["links"] = "links"
+    label: Optional[str] = None
+    links: List[Link] = Field(default_factory=list)
+
+
+Block = Annotated[
+    Union[TextBlock, FactsBlock, TableBlock, LinksBlock],
+    Field(discriminator="type"),
+]
+
+
+class CardAction(BaseModel):
+    """A button on a card.
+
+    `id` is the stable machine identifier a surface posts back. `label` is
+    what the human reads AND what team members match on, so changing a
+    label is a behavioural change, not a cosmetic one.
+    """
+
+    id: str
+    label: str
+    style: Literal["primary", "danger", "neutral"] = "neutral"
+    confirm: Optional[str] = None
+
+
+# --------------------------------------------------------------------------
+# Plain-dict helpers (used by the storage layer, which stays pydantic-free)
+# --------------------------------------------------------------------------
+
+_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(label: str) -> str:
+    """Derive a stable action id from a human label ("Approve Purchase" ->
+    "approve-purchase"). Only used for legacy cards, whose actions are
+    bare strings with no id of their own."""
+    return _SLUG_STRIP.sub("-", str(label).lower()).strip("-") or "action"
+
+
+def _render_block(block: Dict[str, Any]) -> str:
+    kind = block.get("type")
+    label = block.get("label")
+    head = f"{label}:\n" if label else ""
+
+    if kind == "text":
+        return head + str(block.get("text", ""))
+
+    if kind == "facts":
+        lines = [f"{f.get('key')}: {f.get('value')}" for f in block.get("facts") or []]
+        return head + "\n".join(lines)
+
+    if kind == "table":
+        columns = [str(c) for c in block.get("columns") or []]
+        rows = block.get("rows") or []
+        lines = []
+        if columns:
+            lines.append(" | ".join(columns))
+        for row in rows:
+            lines.append(" | ".join(str(cell) for cell in row))
+        return head + "\n".join(lines)
+
+    if kind == "links":
+        lines = [f"{link.get('label')}: {link.get('url')}" for link in block.get("links") or []]
+        return head + "\n".join(lines)
+
+    # Unknown block type: never silently drop content a surface can't
+    # render — fall back to its JSON-ish repr so the text form still
+    # carries it.
+    return head + str(block)
+
+
+def derive_body(blocks: List[Dict[str, Any]]) -> str:
+    """Render blocks to the plaintext `body` older readers still expect.
+
+    Deliberately reproduces the "Label:\\n...\\n\\nLabel:\\n..." shape that
+    members were building by hand, so the derived body is not a
+    regression for anything reading it today."""
+    return "\n\n".join(_render_block(b) for b in blocks if b)
+
+
+def normalize_actions(actions: Any) -> List[Dict[str, Any]]:
+    """Coerce either legacy `["Approve", "Reject"]` or typed action dicts
+    into a uniform list of action dicts."""
+    if not isinstance(actions, list):
+        return []
+
+    normalized: List[Dict[str, Any]] = []
+    for action in actions:
+        if isinstance(action, str):
+            normalized.append(
+                {"id": slugify(action), "label": action, "style": "neutral", "confirm": None}
+            )
+        elif isinstance(action, dict):
+            label = action.get("label") or action.get("id") or "Action"
+            normalized.append(
+                {
+                    "id": action.get("id") or slugify(label),
+                    "label": label,
+                    "style": action.get("style") or "neutral",
+                    "confirm": action.get("confirm"),
+                }
+            )
+    return normalized
+
+
+def normalize_card(item: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a copy of a stored card in the current schema.
+
+    Legacy records (no `blocks`) are upgraded in memory: `body` becomes a
+    single text block and string actions gain derived ids. Nothing is
+    written back — storage keeps whatever shape it already had."""
+    if item is None:
+        return None
+
+    card = dict(item)
+    blocks = card.get("blocks")
+
+    if not isinstance(blocks, list) or not blocks:
+        body = card.get("body") or ""
+        card["blocks"] = [{"type": "text", "label": None, "text": body}] if body else []
+
+    card["actions"] = normalize_actions(card.get("actions"))
+    card["schema_version"] = card.get("schema_version") or SCHEMA_VERSION
+    return card
+
+
+def resolve_action(item: Optional[Dict[str, Any]], action_id: str) -> Optional[str]:
+    """Map an action id back to the label team members match on.
+
+    Returns None when the card has no such action — the caller must treat
+    that as a rejected request rather than inventing a label, or a surface
+    could trigger an action the card never offered."""
+    card = normalize_card(item)
+    if not card:
+        return None
+    for action in card.get("actions") or []:
+        if action.get("id") == action_id:
+            return action.get("label")
+    return None

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -67,6 +67,47 @@ interactive agent can drive its own sub-agents and bots this way.
 3. Done — routing, X replies, timeline cards, and dispatcher callbacks are
    handled by the framework.
 
+## Writing a card
+
+A card is how a member asks a human to look at something and, when it carries
+actions, to authorize something. Build one with the helpers in
+`agents/base.py` — never hand-roll the dict, or your content won't render on
+the approval surface at `/ui`.
+
+```python
+from agents.base import (
+    approve_reject, build_card, facts_block, links_block, table_block, text_block,
+)
+
+card = build_card(
+    title="Shopping picks",
+    blocks=[
+        text_block(mention.text, label="Request"),
+        table_block(["Item", "Price"], [["Speedgoat 6", "$145"]], label="Picks"),
+        links_block([{"label": "Source", "url": "https://…"}], label="Sources"),
+    ],
+    actions=approve_reject("Approve Purchase", "Reject"),
+    metadata={"agent_id": self.profile.id, "action_type": "purchase"},
+)
+```
+
+Block types are `text`, `facts`, `table`, and `links`. The set is deliberately
+small — every surface must be able to render every type, so adding one is a
+real cost rather than a free extension.
+
+Two rules matter when your card has actions:
+
+- **`metadata["agent_id"]` is required.** The dispatcher routes an approval
+  back to the member that proposed it via this field. Without it the card
+  falls through to the generic Grok executor.
+- **Action labels are the contract.** `execute_action()` receives the *label*,
+  not the id, so `approve_reject("Approve Purchase", …)` must be matched by
+  code that checks for `"Approve Purchase"`. Changing a label is a
+  behavioural change.
+
+Cards with no actions (a research brief, an error report) are informational —
+pass no `actions` and the surface renders them without buttons.
+
 ## Safety defaults
 
 - **Trades are paper-only.** `PaperBroker` writes simulated fills to a local
@@ -75,6 +116,12 @@ interactive agent can drive its own sub-agents and bots this way.
   no payment adapter ships with the repo.
 - **Actions are approval-gated.** Cards with side effects require a human
   action on the timeline before the dispatcher executes anything.
+- **Approvals are authenticated** when `TIMELINE_API_TOKEN` is set. It is
+  empty by default for local use, and the timeline server warns at startup
+  when it is — set it before exposing the service, or anyone who can reach
+  the port can approve agent actions.
+- **A surface can only trigger actions the card offers.** Posting an
+  `action_id` the card doesn't carry is rejected with a 400.
 
 ## X API Exhibit
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -116,12 +116,19 @@ pass no `actions` and the surface renders them without buttons.
   no payment adapter ships with the repo.
 - **Actions are approval-gated.** Cards with side effects require a human
   action on the timeline before the dispatcher executes anything.
-- **Approvals are authenticated** when `TIMELINE_API_TOKEN` is set. It is
-  empty by default for local use, and the timeline server warns at startup
-  when it is — set it before exposing the service, or anyone who can reach
-  the port can approve agent actions.
-- **A surface can only trigger actions the card offers.** Posting an
-  `action_id` the card doesn't carry is rejected with a 400.
+- **Approvals are authenticated** when `TIMELINE_API_TOKEN` is set. It is empty
+  by default for local use. On a deployment (detected via `RAILWAY_SERVICE_NAME`
+  and friends) an empty token makes the app refuse to start rather than serve
+  approvals anonymously; the check runs at import time so it covers every
+  entrypoint, including `uvicorn main:app`. `TIMELINE_ALLOW_INSECURE=1`
+  overrides it deliberately.
+- **A surface can only trigger actions the card offers.** Both an unknown
+  `action_id` and a bare `action` label the card doesn't carry are rejected
+  with a 400, and nothing is dispatched. Sending an `action` that contradicts
+  the supplied `action_id` is also a 400.
+- **Card links are http(s) only.** `links_block` drops other schemes and the
+  API rejects them, because card content derives from model output over
+  untrusted mentions and lands in the approval UI's DOM.
 
 ## X API Exhibit
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,12 +6,19 @@
 
 Deploy **four services** from this same repository:
 
-| Service | Start command |
-|---|---|
-| `mcp-server` | `python server.py` |
-| `timeline-server` | `python timeline_server.py` |
-| `listener` | `python listener.py` |
-| `mcp-dispatcher` | `python mcp_dispatcher.py` |
+| Service name | Start command | Runs |
+|---|---|---|
+| `mcp-server` | `python server.py` | MCP tools over the X API |
+| `timeline-server` | `python timeline_server.py` | Timeline + A2A API and the `/ui` approval surface |
+| `listener` | `python listener.py` | X mention poller |
+| `mcp-dispatcher` | `python mcp_dispatcher.py` | Timeline action executor |
+
+**The service name is load-bearing.** Railway will start this repo with
+`uvicorn main:app` unless you set a start command, and `main.py` picks what to
+run from `RAILWAY_SERVICE_NAME`. A name it does not recognise yields a
+container that answers `/health` and runs no worker at all, which looks
+healthy. Either set the start commands above, or name each service exactly as
+in the first column.
 
 Add a Railway Postgres plugin, then set the **same** `DATABASE_URL` on all four services.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -25,6 +25,31 @@ The timeline and A2A schema are auto-created at startup. If you are migrating ol
 python scripts/migrate_json_to_sql.py
 ```
 
+#### Required environment for the Python stack
+
+Set these on **every** service — Railway services do not inherit each other's
+environment.
+
+| Variable | Why |
+|---|---|
+| `DATABASE_URL` | Shared Postgres, as above. Unset means each service gets its own local SQLite file, which is almost never what you want on Railway. |
+| `TIMELINE_API_TOKEN` | **Required on a deployment.** This API includes the PATCH that authorizes agent actions, so an empty value makes `timeline-server` refuse to start rather than serve approvals anonymously. Generate with `openssl rand -hex 32`. |
+| `XAI_API_KEY` | Grok reasoning for the listener and dispatcher. |
+| X API credentials | `X_BEARER_TOKEN`, `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_SECRET` — the listener needs them to read mentions and reply. |
+
+Wire the cross-service URLs after the first deploy: set `MCP_SERVER_URL` and
+`TIMELINE_API_URL` on `listener` and `mcp-dispatcher` to the deployed
+`mcp-server` and `timeline-server` URLs.
+
+`TIMELINE_ALLOW_INSECURE=1` overrides the token requirement. Only do that on a
+deliberately closed network — approvals become anonymous to anyone who can
+reach the port.
+
+The approval UI is served by `timeline-server` at `/ui`.
+
+> The environment-variable tables further down this document describe the
+> standalone TypeScript agent in `src/`, not this service stack.
+
 ### 1. Local Development Machine
 
 **Best for:** Testing and personal use

--- a/env.example
+++ b/env.example
@@ -37,6 +37,18 @@ A2A_STORE_PATH=~/.xmcp/a2a_store.json
 TIMELINE_ACTION_AGENT=mcp-orchestrator
 MCP_DISPATCH_AGENT_ID=mcp-orchestrator
 
+# Shared bearer token for the timeline + A2A API and the approval UI.
+# Leave empty for local-only use; the server logs a warning at startup.
+# This API includes the approval PATCH that authorizes agent actions, so
+# any deployment reachable beyond localhost MUST set this. Every internal
+# service (listener, dispatcher, agents) reads the same value.
+TIMELINE_API_TOKEN=
+
+# Comma-separated origins allowed to call the API from a browser. The
+# bundled UI at /ui is same-origin, so leave this empty unless a surface
+# is hosted separately. e.g. https://timeline.example.com
+TIMELINE_CORS_ORIGINS=
+
 # ─────────────────────────────────────────────
 # Listener / Dispatcher state
 # ─────────────────────────────────────────────

--- a/env.example
+++ b/env.example
@@ -46,6 +46,9 @@ MCP_DISPATCH_AGENT_ID=mcp-orchestrator
 # This API includes the approval PATCH that authorizes agent actions.
 #
 #   Local (no deployment marker): empty is allowed; the server warns loudly.
+#   NOTE: "deployment" is detected only via the markers below. A VPS, Fly,
+#   Render, or docker compose on a public host looks local to that check, so
+#   an empty token there is a warning and NOT a refusal -- set this yourself.
 #   Deployment (RAILWAY_SERVICE_NAME / RAILWAY_ENVIRONMENT /
 #   KUBERNETES_SERVICE_HOST set): empty is FATAL — the app refuses to start
 #   rather than serve approvals anonymously. Enforced at import time, so it

--- a/env.example
+++ b/env.example
@@ -38,11 +38,22 @@ TIMELINE_ACTION_AGENT=mcp-orchestrator
 MCP_DISPATCH_AGENT_ID=mcp-orchestrator
 
 # Shared bearer token for the timeline + A2A API and the approval UI.
-# Leave empty for local-only use; the server logs a warning at startup.
-# This API includes the approval PATCH that authorizes agent actions, so
-# any deployment reachable beyond localhost MUST set this. Every internal
-# service (listener, dispatcher, agents) reads the same value.
+# This API includes the approval PATCH that authorizes agent actions.
+#
+#   Local (no deployment marker): empty is allowed; the server warns loudly.
+#   Deployment (RAILWAY_SERVICE_NAME / RAILWAY_ENVIRONMENT /
+#   KUBERNETES_SERVICE_HOST set): empty is FATAL — the app refuses to start
+#   rather than serve approvals anonymously. Enforced at import time, so it
+#   covers `uvicorn main:app` too. Override with TIMELINE_ALLOW_INSECURE=1.
+#
+# Every internal service (listener, dispatcher, agents) must read the same
+# value. docker compose shares this file; separate Railway services do NOT
+# inherit each other's env — set it on each one.
 TIMELINE_API_TOKEN=
+
+# Set to 1 to allow a deployment to run with an empty TIMELINE_API_TOKEN.
+# Only for a deliberately closed network; approvals become anonymous.
+TIMELINE_ALLOW_INSECURE=
 
 # Comma-separated origins allowed to call the API from a browser. The
 # bundled UI at /ui is same-origin, so leave this empty unless a surface

--- a/listener.py
+++ b/listener.py
@@ -9,7 +9,7 @@ import tweepy
 from dotenv import load_dotenv
 from tweepy.errors import HTTPException as TweepyHTTPException
 
-from agents.base import MentionContext
+from agents.base import MentionContext, build_card, text_block, timeline_headers
 from agents.registry import register_team, route_mention
 
 LAST_SEEN_PATH = Path(os.getenv("XMCP_LAST_SEEN_PATH", "~/.xmcp/last_seen.txt")).expanduser()
@@ -54,11 +54,17 @@ def push_timeline_card(card: dict, posted_by: str) -> None:
         "user_id": user_id,
         "title": card.get("title", "Untitled"),
         "body": card.get("body", ""),
+        "blocks": card.get("blocks", []),
         "posted_by": posted_by,
         "actions": card.get("actions", []),
         "metadata": card.get("metadata", {}),
     }
-    response = requests.post(f"{timeline_url}/v1/timeline/items", json=payload, timeout=10)
+    response = requests.post(
+        f"{timeline_url}/v1/timeline/items",
+        json=payload,
+        headers=timeline_headers(),
+        timeout=10,
+    )
     # Surface 4xx/5xx as failures so the caller holds the watermark and
     # retries — a lost card would silently defeat the approval gate.
     response.raise_for_status()
@@ -97,16 +103,18 @@ def process_mention(client: tweepy.Client, mention) -> bool:
         # watermark and retry the mention next poll.
         try:
             push_timeline_card(
-                {
-                    "title": f"Agent error on mention {mention.id}",
-                    "body": f"{member.profile.id} failed: {exc}\n\nMention:\n{mention.text}",
-                    "actions": [],
-                    "metadata": {
+                build_card(
+                    title=f"Agent error on mention {mention.id}",
+                    blocks=[
+                        text_block(f"{member.profile.id} failed: {exc}", label="Error"),
+                        text_block(mention.text, label="Mention"),
+                    ],
+                    metadata={
                         "agent_id": member.profile.id,
                         "mention_id": mention.id,
                         "error": str(exc),
                     },
-                },
+                ),
                 posted_by=member.profile.id,
             )
             return True
@@ -135,16 +143,18 @@ def process_mention(client: tweepy.Client, mention) -> bool:
         # (and any side effects) already landed.
         try:
             push_timeline_card(
-                {
-                    "title": f"Failed to post reply to mention {mention.id}",
-                    "body": f"Intended reply:\n{reply.text}\n\nError: {exc}",
-                    "actions": [],
-                    "metadata": {
+                build_card(
+                    title=f"Failed to post reply to mention {mention.id}",
+                    blocks=[
+                        text_block(reply.text, label="Intended reply"),
+                        text_block(str(exc), label="Error"),
+                    ],
+                    metadata={
                         "agent_id": member.profile.id,
                         "mention_id": mention.id,
                         "error": str(exc),
                     },
-                },
+                ),
                 posted_by=member.profile.id,
             )
         except Exception as recovery_exc:

--- a/main.py
+++ b/main.py
@@ -47,11 +47,21 @@ def _build_worker_app(kind: str) -> FastAPI:
         return {"ok": True}
 
     def _start_worker() -> None:
-        if kind == "x-listener":
+        # Accept the names docs/DEPLOYMENT.md tells operators to use as well as
+        # the original ones. A service whose name matched neither used to come
+        # up healthy with no worker running at all -- /health returned ok and
+        # nothing ever polled X.
+        if kind in ("x-listener", "listener"):
             from listener import main as run
-        elif kind == "mcp-dispatcher":
+        elif kind in ("mcp-dispatcher", "dispatcher"):
             from mcp_dispatcher import main as run
         else:
+            print(
+                f"WARNING: no worker is defined for RAILWAY_SERVICE_NAME={kind!r}; "
+                "this container will stay up and do nothing. Expected one of: "
+                "mcp-server, timeline-server, listener, mcp-dispatcher.",
+                flush=True,
+            )
             return
 
         thread = threading.Thread(target=run, name=f"{kind}-thread", daemon=True)
@@ -71,7 +81,7 @@ if service == "timeline-server":
     from timeline_server import app as app  # noqa: F401
 elif service == "mcp-server":
     app = _build_mcp_server_app()
-elif service in {"x-listener", "mcp-dispatcher"}:
+elif service in {"x-listener", "listener", "mcp-dispatcher", "dispatcher"}:
     app = _build_worker_app(service)
 else:
     # Safe default for unknown service names.

--- a/mcp_dispatcher.py
+++ b/mcp_dispatcher.py
@@ -10,6 +10,7 @@ from xai_sdk import Client
 from xai_sdk.chat import user
 from xai_sdk.tools import mcp
 
+from agents.base import timeline_headers
 from agents.registry import find_member
 
 LAST_SEEN_PATH = Path(os.getenv("XMCP_DISPATCH_LAST_SEEN", "~/.xmcp/dispatch_last_seen.txt")).expanduser()
@@ -35,7 +36,11 @@ def load_last_seen() -> Optional[str]:
 def get_timeline_item(item_id: str) -> Optional[Dict]:
     timeline_url = os.getenv("TIMELINE_API_URL", "http://127.0.0.1:8080")
     try:
-        response = requests.get(f"{timeline_url}/v1/timeline/items/{item_id}", timeout=10)
+        response = requests.get(
+            f"{timeline_url}/v1/timeline/items/{item_id}",
+            headers=timeline_headers(),
+            timeout=10,
+        )
         if response.status_code != 200:
             return None
         return response.json()
@@ -46,7 +51,11 @@ def get_timeline_item(item_id: str) -> Optional[Dict]:
 
 def get_messages(agent_id: str) -> list[Dict]:
     timeline_url = os.getenv("TIMELINE_API_URL", "http://127.0.0.1:8080")
-    response = requests.get(f"{timeline_url}/v1/a2a/agents/{agent_id}/messages", timeout=10)
+    response = requests.get(
+        f"{timeline_url}/v1/a2a/agents/{agent_id}/messages",
+        headers=timeline_headers(),
+        timeout=10,
+    )
     if response.status_code != 200:
         return []
     payload = response.json()
@@ -64,6 +73,7 @@ def send_message(from_agent: str, to: str, content: str, metadata: Dict) -> None
             "content": content,
             "metadata": metadata,
         },
+        headers=timeline_headers(),
         timeout=10,
     )
 
@@ -78,7 +88,12 @@ def ensure_agent_registered(agent_id: str) -> None:
         "endpoint": "local",
         "tags": ["mcp", "orchestrator"],
     }
-    requests.post(f"{timeline_url}/v1/a2a/agents", json=payload, timeout=10)
+    requests.post(
+        f"{timeline_url}/v1/a2a/agents",
+        json=payload,
+        headers=timeline_headers(),
+        timeout=10,
+    )
 
 
 def update_timeline_item(item_id: str, metadata: Dict) -> None:
@@ -86,6 +101,7 @@ def update_timeline_item(item_id: str, metadata: Dict) -> None:
     requests.patch(
         f"{timeline_url}/v1/timeline/items/{item_id}",
         json={"metadata": metadata},
+        headers=timeline_headers(),
         timeout=10,
     )
 

--- a/scripts/migrate_json_to_sql.py
+++ b/scripts/migrate_json_to_sql.py
@@ -11,24 +11,34 @@ from cards import normalize_actions
 from storage_db import a2a_agents, a2a_messages, timeline_items, write_connection
 
 
-def _parse_timestamp(value: Any) -> datetime:
+def _parse_timestamp(value: Any, *, field: str = "created_at") -> datetime:
+    """Parse a stored timestamp, or fail.
+
+    Substituting now() for an unparsable value silently reorders the timeline
+    and, because the UPDATE path used to write created_at back, moved the
+    record forward again on every re-run. A migration that cannot read its
+    own input should say so."""
     if isinstance(value, datetime):
         return value
     if isinstance(value, str) and value:
         try:
             return datetime.fromisoformat(value)
-        except ValueError:
-            pass
+        except ValueError as exc:
+            raise ValueError(f"unparsable {field} {value!r}") from exc
     return datetime.now(timezone.utc)
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
+    """Read a JSON store, or fail loudly.
+
+    A corrupt file must not read as "nothing to migrate". This is a one-shot
+    move of the only copy of the data: swallowing a decode error here reports
+    `inserted=0` under a "Migration complete" banner and exits 0, and the
+    operator deletes the JSON store on the strength of that. A truncated or
+    partially flushed file is exactly how a JSON store dies."""
     if not path.exists():
         return {}
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _upsert_timeline_items(items: Iterable[Dict[str, Any]]) -> Tuple[int, int]:
@@ -60,7 +70,13 @@ def _upsert_timeline_items(items: Iterable[Dict[str, Any]]) -> Tuple[int, int]:
                 select(timeline_items.c.id).where(timeline_items.c.id == item_id)
             ).fetchone()
             if exists:
-                conn.execute(update(timeline_items).where(timeline_items.c.id == item_id).values(**payload))
+                # created_at belongs to the original record; a re-run must not
+                # move it.
+                conn.execute(
+                    update(timeline_items)
+                    .where(timeline_items.c.id == item_id)
+                    .values(**{k: v for k, v in payload.items() if k != "created_at"})
+                )
                 updated += 1
             else:
                 conn.execute(insert(timeline_items).values(**payload))

--- a/storage_db.py
+++ b/storage_db.py
@@ -50,6 +50,10 @@ timeline_items = Table(
     # that predates typed cards keeps working.
     Column("blocks", json_type, nullable=False, default=list),
     Column("schema_version", String, nullable=False, default=""),
+    # The action this card has already dispatched, or "" while unclaimed. A
+    # conditional UPDATE against this column is what makes approval
+    # single-shot; see timeline_store.claim_action.
+    Column("dispatched_action", String, nullable=False, default=""),
     Column("status", String, nullable=False, index=True),
     Column("posted_by", String, nullable=False),
     Column("actions", json_type, nullable=False),

--- a/storage_db.py
+++ b/storage_db.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import DBAPIError
 
 DEFAULT_DB_PATH = Path("~/.xmcp/xmcp.db").expanduser()
 SQLITE_BUSY_TIMEOUT_MS = int(os.getenv("SQLITE_BUSY_TIMEOUT_MS", "5000"))
@@ -113,6 +114,19 @@ def _configure_sqlite(engine: Engine) -> None:
         cursor.close()
 
 
+def _is_duplicate_column(exc: DBAPIError) -> bool:
+    """Whether a failed ADD COLUMN failed only because the column is there.
+
+    Matched on message text rather than a driver error code, because the two
+    backends raise unrelated exception types (psycopg's DuplicateColumn vs
+    SQLite's generic OperationalError). Anything that is not recognisably a
+    duplicate column is re-raised -- a genuinely broken migration must not be
+    swallowed here.
+    """
+    message = str(getattr(exc, "orig", exc)).lower()
+    return "already exists" in message or "duplicate column" in message
+
+
 def _add_missing_columns(engine: Engine) -> None:
     """Add columns that `create_all` won't.
 
@@ -122,6 +136,14 @@ def _add_missing_columns(engine: Engine) -> None:
     migration framework here, so bring the one table that has gained columns
     up to date in place. Each ADD COLUMN is guarded by a live reflection, which
     makes this a no-op on an already-current database.
+
+    The reflection is not a lock, though. All four services boot at once and
+    share one database, so several can reflect "missing" before any of them
+    alters, and the losers of that race would otherwise crash on startup with
+    a duplicate-column error. Each statement therefore runs in its own
+    transaction (an error poisons the whole transaction on Postgres, which
+    would strand any column after the first) and treats "already exists" as
+    success -- another process adding the column is the desired end state.
     """
     inspector = inspect(engine)
     if not inspector.has_table(timeline_items.name):
@@ -134,18 +156,21 @@ def _add_missing_columns(engine: Engine) -> None:
 
     type_compiler = engine.dialect.type_compiler_instance
     preparer = engine.dialect.identifier_preparer
-    with engine.begin() as conn:
-        for column in missing:
-            # Existing rows need a value for a NOT NULL column, so every
-            # backfillable column added here carries a constant default.
-            default = "'[]'" if column.name == "blocks" else "''"
-            conn.execute(
-                text(
-                    f"ALTER TABLE {preparer.format_table(timeline_items)} "
-                    f"ADD COLUMN {preparer.quote(column.name)} "
-                    f"{type_compiler.process(column.type)} NOT NULL DEFAULT {default}"
-                )
-            )
+    for column in missing:
+        # Existing rows need a value for a NOT NULL column, so every
+        # backfillable column added here carries a constant default.
+        default = "'[]'" if column.name == "blocks" else "''"
+        statement = text(
+            f"ALTER TABLE {preparer.format_table(timeline_items)} "
+            f"ADD COLUMN {preparer.quote(column.name)} "
+            f"{type_compiler.process(column.type)} NOT NULL DEFAULT {default}"
+        )
+        try:
+            with engine.begin() as conn:
+                conn.execute(statement)
+        except DBAPIError as exc:
+            if not _is_duplicate_column(exc):
+                raise
 
 
 def _create_engine() -> Engine:

--- a/storage_db.py
+++ b/storage_db.py
@@ -26,6 +26,11 @@ from sqlalchemy.exc import DBAPIError
 DEFAULT_DB_PATH = Path("~/.xmcp/xmcp.db").expanduser()
 SQLITE_BUSY_TIMEOUT_MS = int(os.getenv("SQLITE_BUSY_TIMEOUT_MS", "5000"))
 
+# Literal SQL defaults for backfilling NOT NULL columns onto existing rows.
+# A NOT NULL column added without one cannot be applied to a populated table,
+# so a missing entry here is a programming error rather than a default.
+_BACKFILL_DEFAULTS = {"blocks": "'[]'", "schema_version": "''", "dispatched_action": "''"}
+
 # Bounded, because losing the create race is expected and transient: the retry
 # only has to outlast another process committing its CREATE TABLE.
 _SCHEMA_CREATE_ATTEMPTS = 3
@@ -167,13 +172,26 @@ def _add_missing_columns(engine: Engine) -> None:
     type_compiler = engine.dialect.type_compiler_instance
     preparer = engine.dialect.identifier_preparer
     for column in missing:
-        # Existing rows need a value for a NOT NULL column, so every
-        # backfillable column added here carries a constant default.
-        default = "'[]'" if column.name == "blocks" else "''"
+        # Read the intent off the Column rather than hardcoding it. Every
+        # column added so far happens to be String/JSON and NOT NULL, and a
+        # blanket "NOT NULL DEFAULT ''" works only for those: a DateTime would
+        # be rejected by Postgres and silently store garbage in SQLite, and a
+        # nullable column would be forced NOT NULL against its own definition.
+        # This path exists for legacy databases, so that lands on startup in
+        # production rather than in a fresh test database.
+        constraint = ""
+        if not column.nullable:
+            default = _BACKFILL_DEFAULTS.get(column.name)
+            if default is None:
+                raise RuntimeError(
+                    f"{timeline_items.name}.{column.name} is NOT NULL with no backfill "
+                    "default; existing rows need one -- add it to _BACKFILL_DEFAULTS"
+                )
+            constraint = f" NOT NULL DEFAULT {default}"
         statement = text(
             f"ALTER TABLE {preparer.format_table(timeline_items)} "
             f"ADD COLUMN {preparer.quote(column.name)} "
-            f"{type_compiler.process(column.type)} NOT NULL DEFAULT {default}"
+            f"{type_compiler.process(column.type)}{constraint}"
         )
         try:
             with engine.begin() as conn:

--- a/storage_db.py
+++ b/storage_db.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,11 @@ from sqlalchemy.exc import DBAPIError
 
 DEFAULT_DB_PATH = Path("~/.xmcp/xmcp.db").expanduser()
 SQLITE_BUSY_TIMEOUT_MS = int(os.getenv("SQLITE_BUSY_TIMEOUT_MS", "5000"))
+
+# Bounded, because losing the create race is expected and transient: the retry
+# only has to outlast another process committing its CREATE TABLE.
+_SCHEMA_CREATE_ATTEMPTS = 3
+_SCHEMA_RETRY_DELAY_S = 0.25
 
 _ENGINE: Optional[Engine] = None
 _ENGINE_LOCK = threading.Lock()
@@ -173,6 +179,31 @@ def _add_missing_columns(engine: Engine) -> None:
                 raise
 
 
+def _create_tables(engine: Engine) -> None:
+    """Create the schema, tolerating another service creating it concurrently.
+
+    `create_all` checks which tables exist and then creates the rest, which is
+    the same reflect-then-write race as `_add_missing_columns` -- and it bites
+    harder, because it happens on the *first* deploy against an empty database
+    with every service booting at once. Postgres fails the loser with a unique
+    violation on its own catalog rather than anything table-specific, so the
+    resolution is to ask whether the schema is there now: if it is, whoever
+    created it did the job.
+    """
+    expected = set(metadata.tables)
+    for attempt in range(_SCHEMA_CREATE_ATTEMPTS):
+        try:
+            metadata.create_all(engine)
+            return
+        except DBAPIError:
+            # Reflect fresh -- the winner may still have been committing.
+            if expected <= set(inspect(engine).get_table_names()):
+                return
+            if attempt == _SCHEMA_CREATE_ATTEMPTS - 1:
+                raise
+            time.sleep(_SCHEMA_RETRY_DELAY_S * (attempt + 1))
+
+
 def _create_engine() -> Engine:
     database_url = get_database_url()
     connect_args: Dict[str, Any] = {}
@@ -181,7 +212,7 @@ def _create_engine() -> Engine:
     engine = create_engine(database_url, future=True, pool_pre_ping=True, connect_args=connect_args)
     if database_url.startswith("sqlite://"):
         _configure_sqlite(engine)
-    metadata.create_all(engine)
+    _create_tables(engine)
     _add_missing_columns(engine)
     return engine
 

--- a/store_lock.py
+++ b/store_lock.py
@@ -1,0 +1,57 @@
+"""Cross-process advisory file locking for the JSON-file stores.
+
+The timeline, A2A, and paper-trade stores are plain JSON files written by
+four separate processes (server, timeline server, listener, dispatcher).
+A `threading.Lock` only serializes writers inside one interpreter, so a
+read-modify-write can still lose updates across processes. `file_lock`
+closes that gap with an `flock` on a sibling `.lock` file.
+
+Callers must hold the lock across the *whole* read-modify-write, not just
+the write, or the race is merely narrowed rather than closed.
+"""
+
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict
+
+# One re-entrant-ish thread lock per store path, so threads inside a single
+# process serialize before they ever contend on the OS-level lock.
+_THREAD_LOCKS: Dict[str, threading.Lock] = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _thread_lock_for(path: Path) -> threading.Lock:
+    key = str(path)
+    with _THREAD_LOCKS_GUARD:
+        lock = _THREAD_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _THREAD_LOCKS[key] = lock
+        return lock
+
+
+@contextmanager
+def file_lock(target_path: Path):
+    """Serialize access to `target_path` across threads and processes.
+
+    fcntl is Unix-only; on platforms without it the thread lock still
+    applies and the cross-process guarantee degrades to best-effort
+    (matching the previous behaviour of the paper-trade ledger)."""
+    target_path = Path(target_path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _thread_lock_for(target_path):
+        try:
+            import fcntl
+        except ImportError:
+            yield
+            return
+
+        lock_file = target_path.with_suffix(target_path.suffix + ".lock")
+        with open(lock_file, "w") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle, fcntl.LOCK_UN)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -110,7 +110,7 @@ def test_resolve_action_rejects_an_action_the_card_never_offered():
 def test_unsafe_link_urls_are_rejected(url):
     # These would otherwise land in an anchor's href in the approval UI,
     # where they'd execute alongside the bearer token.
-    assert is_safe_url(url) is True  # TEMPORARY: proving the CI gate can fail
+    assert is_safe_url(url) is False
     with pytest.raises(ValidationError):
         Link(label="x", url=url)
 

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,6 +1,12 @@
+import pytest
+from pydantic import ValidationError
+
 from cards import (
     SCHEMA_VERSION,
+    DuplicateActionIdError,
+    Link,
     derive_body,
+    is_safe_url,
     normalize_actions,
     normalize_card,
     resolve_action,
@@ -86,6 +92,60 @@ def test_resolve_action_rejects_an_action_the_card_never_offered():
     card = {"body": "brief", "actions": []}
     assert resolve_action(card, "approve") is None
     assert resolve_action(None, "approve") is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        "  javascript:alert(1)  ",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "vbscript:msgbox(1)",
+        "file:///etc/passwd",
+        "not a url",
+        "",
+    ],
+)
+def test_unsafe_link_urls_are_rejected(url):
+    # These would otherwise land in an anchor's href in the approval UI,
+    # where they'd execute alongside the bearer token.
+    assert is_safe_url(url) is False
+    with pytest.raises(ValidationError):
+        Link(label="x", url=url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["https://x.com/search?q=%24TSLA", "http://localhost:8080/ui", "HTTPS://X.COM"],
+)
+def test_safe_link_urls_are_preserved(url):
+    assert is_safe_url(url) is True
+    assert Link(label="x", url=url).url == url
+
+
+def test_duplicate_action_ids_are_rejected_in_strict_mode():
+    typed = [
+        {"id": "approve", "label": "Approve Purchase"},
+        {"id": "approve", "label": "Approve Something Else"},
+    ]
+    with pytest.raises(DuplicateActionIdError):
+        normalize_actions(typed, strict=True)
+
+    # Distinct legacy labels can still collide after slugifying.
+    with pytest.raises(DuplicateActionIdError):
+        normalize_actions(["Approve!", "Approve?"], strict=True)
+
+
+def test_duplicate_action_ids_are_tolerated_when_reading_stored_cards():
+    # A bad historical record must not make the whole timeline unreadable.
+    actions = normalize_actions([{"id": "approve", "label": "A"}, {"id": "approve", "label": "B"}])
+    assert len(actions) == 2
+
+
+def test_unique_action_ids_pass_strict_mode():
+    actions = normalize_actions(["Approve", "Reject"], strict=True)
+    assert [a["id"] for a in actions] == ["approve", "reject"]
 
 
 def test_resolve_action_works_on_legacy_string_actions():

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,95 @@
+from cards import (
+    SCHEMA_VERSION,
+    derive_body,
+    normalize_actions,
+    normalize_card,
+    resolve_action,
+    slugify,
+)
+
+
+def test_slugify_derives_stable_ids():
+    assert slugify("Approve Purchase") == "approve-purchase"
+    assert slugify("Reject") == "reject"
+    # Never produce an empty id, or an action becomes unaddressable.
+    assert slugify("!!!") == "action"
+
+
+def test_derive_body_renders_every_block_type():
+    body = derive_body(
+        [
+            {"type": "text", "label": "Question", "text": "why is it down?"},
+            {"type": "facts", "label": "Order", "facts": [{"key": "Side", "value": "BUY"}]},
+            {"type": "table", "columns": ["Item", "Price"], "rows": [["Shoe", "$120"]]},
+            {"type": "links", "links": [{"label": "src", "url": "https://x.com"}]},
+        ]
+    )
+    assert "Question:\nwhy is it down?" in body
+    assert "Order:\nSide: BUY" in body
+    assert "Item | Price" in body
+    assert "Shoe | $120" in body
+    assert "src: https://x.com" in body
+
+
+def test_derive_body_keeps_unknown_block_content():
+    # A surface may not render an unknown block, but its content must never
+    # vanish from the text form.
+    body = derive_body([{"type": "future", "payload": "important"}])
+    assert "important" in body
+
+
+def test_normalize_actions_accepts_legacy_strings_and_typed_dicts():
+    assert normalize_actions(["Approve Purchase"]) == [
+        {"id": "approve-purchase", "label": "Approve Purchase", "style": "neutral", "confirm": None}
+    ]
+    typed = normalize_actions([{"id": "approve", "label": "Approve", "style": "primary"}])
+    assert typed[0]["id"] == "approve"
+    assert typed[0]["style"] == "primary"
+    assert normalize_actions(None) == []
+
+
+def test_normalize_card_upgrades_a_legacy_record():
+    legacy = {
+        "id": "abc",
+        "title": "Trade proposal",
+        "body": "BUY 10 $TSLA",
+        "actions": ["Approve", "Reject"],
+    }
+    card = normalize_card(legacy)
+
+    assert card["schema_version"] == SCHEMA_VERSION
+    assert card["blocks"] == [{"type": "text", "label": None, "text": "BUY 10 $TSLA"}]
+    assert [a["id"] for a in card["actions"]] == ["approve", "reject"]
+    # The original record is not mutated in place.
+    assert legacy["actions"] == ["Approve", "Reject"]
+
+
+def test_normalize_card_leaves_typed_blocks_alone():
+    blocks = [{"type": "facts", "label": "Order", "facts": [{"key": "Side", "value": "BUY"}]}]
+    card = normalize_card({"blocks": blocks, "body": "derived", "actions": []})
+    assert card["blocks"] == blocks
+
+
+def test_resolve_action_maps_id_to_the_label_members_match_on():
+    card = {
+        "body": "picks",
+        "actions": [
+            {"id": "approve", "label": "Approve Purchase"},
+            {"id": "reject", "label": "Reject"},
+        ],
+    }
+    assert resolve_action(card, "approve") == "Approve Purchase"
+    assert resolve_action(card, "reject") == "Reject"
+
+
+def test_resolve_action_rejects_an_action_the_card_never_offered():
+    card = {"body": "brief", "actions": []}
+    assert resolve_action(card, "approve") is None
+    assert resolve_action(None, "approve") is None
+
+
+def test_resolve_action_works_on_legacy_string_actions():
+    # A card written before typed actions must still be approvable from a
+    # surface that only knows how to post ids.
+    card = {"body": "x", "actions": ["Approve", "Reject"]}
+    assert resolve_action(card, "approve") == "Approve"

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -110,7 +110,7 @@ def test_resolve_action_rejects_an_action_the_card_never_offered():
 def test_unsafe_link_urls_are_rejected(url):
     # These would otherwise land in an anchor's href in the approval UI,
     # where they'd execute alongside the bearer token.
-    assert is_safe_url(url) is False
+    assert is_safe_url(url) is True  # TEMPORARY: proving the CI gate can fail
     with pytest.raises(ValidationError):
         Link(label="x", url=url)
 

--- a/tests/test_sql_storage.py
+++ b/tests/test_sql_storage.py
@@ -10,7 +10,13 @@ import pytest
 import a2a_store
 import timeline_store
 from scripts.migrate_json_to_sql import migrate
-from storage_db import get_engine, metadata, normalize_database_url, reset_engine_for_tests
+from storage_db import (
+    get_engine,
+    metadata,
+    normalize_database_url,
+    reset_engine_for_tests,
+    timeline_items,
+)
 
 # Every column added to timeline_items after #125 shipped the SQL layer. These
 # are what a database created by that revision is missing, so they define both
@@ -18,6 +24,13 @@ from storage_db import get_engine, metadata, normalize_database_url, reset_engin
 # Keep in step with storage_db.timeline_items -- a column added there and not
 # here silently stops being covered.
 COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED = {"blocks", "schema_version", "dispatched_action"}
+
+# A rename is worse than an addition: the stale name lingers here, the legacy
+# table keeps a column that no longer exists, and both upgrade tests pass while
+# testing nothing.
+assert COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED <= {c.name for c in timeline_items.columns}, (
+    "a column named here no longer exists on storage_db.timeline_items"
+)
 
 
 @pytest.fixture()
@@ -242,23 +255,8 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
 
     url = os.getenv("TEST_DATABASE_URL") or f"sqlite:///{tmp_path / 'old.db'}"
 
-    # The table exactly as the previous revision defined it: every current
-    # column except the two this change adds. Copying the real Column objects
-    # keeps the DDL dialect-correct instead of stringly-typed.
-    legacy_meta = MetaData()
-    Table(
-        timeline_items.name,
-        legacy_meta,
-        *[
-            Column(c.name, c.type, primary_key=c.primary_key, nullable=c.nullable)
-            for c in timeline_items.columns
-            if c.name not in COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED
-        ],
-    )
-
+    legacy_meta = _make_legacy_table(url)
     bootstrap = create_engine(normalize_database_url(url), future=True)
-    legacy_meta.drop_all(bootstrap)
-    legacy_meta.create_all(bootstrap)
     with bootstrap.begin() as conn:
         conn.execute(
             legacy_meta.tables[timeline_items.name].insert().values(
@@ -293,8 +291,12 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
 
 
 def _make_legacy_table(url):
-    """The timeline_items table as the revision before blocks/schema_version
-    defined it."""
+    """Build timeline_items as the revision before this branch defined it.
+
+    One definition of "the schema before these columns", used by every upgrade
+    test. Two copies would drift, and the test that drifted would quietly stop
+    testing the schema it names. Returns the MetaData -- the engine it used is
+    disposed here, so returning that would hand back a dead one."""
     from sqlalchemy import Column, MetaData, Table, create_engine
 
     from storage_db import normalize_database_url, timeline_items
@@ -313,7 +315,7 @@ def _make_legacy_table(url):
     legacy.drop_all(engine)
     legacy.create_all(engine)
     engine.dispose()
-    return engine
+    return legacy
 
 
 def test_concurrent_startups_do_not_collide_on_the_column_upgrade(tmp_path, monkeypatch):
@@ -433,3 +435,55 @@ def test_a_first_deploy_boots_every_service_against_an_empty_database(tmp_path, 
     ids = [agent["id"] for agent in a2a_store.list_agents()]
     assert len(ids) == len(set(ids)), f"an agent was seeded twice: {ids}"
     reset_engine_for_tests()
+
+
+def test_a_corrupt_json_store_fails_the_migration_instead_of_reporting_success(
+    db_url, tmp_path, monkeypatch
+):
+    """`inserted=0` under a "Migration complete" banner is how an operator
+    decides it is safe to delete the JSON store. A file this cannot read must
+    not produce that message."""
+    from scripts.migrate_json_to_sql import migrate
+
+    corrupt = tmp_path / "timeline.json"
+    corrupt.write_text('{"items": [{"id": "a"', encoding="utf-8")  # truncated write
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(corrupt))
+    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "missing.json"))
+
+    with pytest.raises(json.JSONDecodeError):
+        migrate()
+
+
+def test_an_unreadable_timestamp_fails_rather_than_becoming_now(db_url, tmp_path, monkeypatch):
+    """Substituting now() reorders the timeline silently."""
+    from scripts.migrate_json_to_sql import migrate
+
+    path = tmp_path / "timeline.json"
+    path.write_text(
+        json.dumps({"items": [{"id": "a", "title": "t", "created_at": "not-a-date"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(path))
+    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "missing.json"))
+
+    with pytest.raises(ValueError, match="unparsable created_at"):
+        migrate()
+
+
+def test_re_running_the_migration_does_not_move_created_at(db_url, tmp_path, monkeypatch):
+    from scripts.migrate_json_to_sql import migrate
+
+    path = tmp_path / "timeline.json"
+    path.write_text(
+        json.dumps(
+            {"items": [{"id": "a", "title": "t", "created_at": "2024-01-01T00:00:00+00:00"}]}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(path))
+    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "missing.json"))
+
+    migrate()
+    first = timeline_store.get_item("a")["created_at"]
+    migrate()
+    assert timeline_store.get_item("a")["created_at"] == first

--- a/tests/test_sql_storage.py
+++ b/tests/test_sql_storage.py
@@ -219,27 +219,51 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
     """`metadata.create_all` leaves an existing table alone, so a database
     created before `blocks`/`schema_version` existed would keep its old column
     set and fail every read. Adding them on connect is what keeps a database
-    written by the previous revision usable."""
-    from sqlalchemy import create_engine, inspect, text
+    written by the previous revision usable.
+
+    This runs against whichever backend the suite is pointed at. That matters:
+    the ADD COLUMN is rendered per dialect, so the Postgres form (JSONB, and a
+    NOT NULL default applied to existing rows) is only actually exercised when
+    TEST_DATABASE_URL is set.
+    """
+    from datetime import datetime, timezone
+
+    from sqlalchemy import Column, MetaData, Table, create_engine, inspect
 
     from storage_db import get_engine, reset_engine_for_tests, timeline_items
 
-    db_path = tmp_path / "old.db"
-    url = f"sqlite:///{db_path}"
+    url = os.getenv("TEST_DATABASE_URL") or f"sqlite:///{tmp_path / 'old.db'}"
 
-    # Build the table as the previous revision defined it: no blocks, no
-    # schema_version, and one row already in it.
-    legacy_columns = [c for c in timeline_items.columns if c.name not in ("blocks", "schema_version")]
-    bootstrap = create_engine(url, future=True)
+    # The table exactly as the previous revision defined it: every current
+    # column except the two this change adds. Copying the real Column objects
+    # keeps the DDL dialect-correct instead of stringly-typed.
+    legacy_meta = MetaData()
+    Table(
+        timeline_items.name,
+        legacy_meta,
+        *[
+            Column(c.name, c.type, primary_key=c.primary_key, nullable=c.nullable)
+            for c in timeline_items.columns
+            if c.name not in ("blocks", "schema_version")
+        ],
+    )
+
+    bootstrap = create_engine(normalize_database_url(url), future=True)
+    legacy_meta.drop_all(bootstrap)
+    legacy_meta.create_all(bootstrap)
     with bootstrap.begin() as conn:
-        cols = ", ".join(f"{c.name} TEXT" for c in legacy_columns)
-        conn.execute(text(f"CREATE TABLE timeline_items ({cols}, PRIMARY KEY (id))"))
         conn.execute(
-            text(
-                "INSERT INTO timeline_items "
-                "(id, user_id, title, body, status, posted_by, actions, metadata, created_at) "
-                "VALUES ('legacy-1', 'default', 'Old card', 'BUY 10 $TSLA', 'unread', "
-                "'tradedesk', '[\"Approve\"]', '{}', '2024-01-01T00:00:00+00:00')"
+            legacy_meta.tables[timeline_items.name].insert().values(
+                id="legacy-1",
+                user_id="default",
+                title="Old card",
+                body="BUY 10 $TSLA",
+                status="unread",
+                posted_by="tradedesk",
+                actions=["Approve"],
+                metadata={},
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                updated_at=None,
             )
         )
     bootstrap.dispose()
@@ -247,10 +271,11 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
     monkeypatch.setenv("DATABASE_URL", url)
     reset_engine_for_tests()
 
-    columns = {c["name"] for c in inspect(get_engine()).get_columns("timeline_items")}
+    columns = {c["name"] for c in inspect(get_engine()).get_columns(timeline_items.name)}
     assert {"blocks", "schema_version"} <= columns
 
-    # The pre-existing row still reads, and upgrades to typed content.
+    # The row written before the columns existed still reads, and upgrades to
+    # typed content rather than erroring on the newly added NOT NULL columns.
     item = timeline_store.get_item("legacy-1")
     assert item is not None
     assert item["blocks"] == [{"type": "text", "label": None, "text": "BUY 10 $TSLA"}]

--- a/tests/test_sql_storage.py
+++ b/tests/test_sql_storage.py
@@ -12,6 +12,13 @@ import timeline_store
 from scripts.migrate_json_to_sql import migrate
 from storage_db import get_engine, metadata, normalize_database_url, reset_engine_for_tests
 
+# Every column added to timeline_items after #125 shipped the SQL layer. These
+# are what a database created by that revision is missing, so they define both
+# the "legacy" table the upgrade tests build and what the upgrade must add.
+# Keep in step with storage_db.timeline_items -- a column added there and not
+# here silently stops being covered.
+COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED = {"blocks", "schema_version", "dispatched_action"}
+
 
 @pytest.fixture()
 def db_url(tmp_path, monkeypatch):
@@ -245,7 +252,7 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
         *[
             Column(c.name, c.type, primary_key=c.primary_key, nullable=c.nullable)
             for c in timeline_items.columns
-            if c.name not in ("blocks", "schema_version")
+            if c.name not in COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED
         ],
     )
 
@@ -273,7 +280,7 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
     reset_engine_for_tests()
 
     columns = {c["name"] for c in inspect(get_engine()).get_columns(timeline_items.name)}
-    assert {"blocks", "schema_version"} <= columns
+    assert COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED <= columns
 
     # The row written before the columns existed still reads, and upgrades to
     # typed content rather than erroring on the newly added NOT NULL columns.
@@ -300,7 +307,7 @@ def _make_legacy_table(url):
         *[
             Column(c.name, c.type, primary_key=c.primary_key, nullable=c.nullable)
             for c in timeline_items.columns
-            if c.name not in ("blocks", "schema_version")
+            if c.name not in COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED
         ],
     )
     legacy.drop_all(engine)
@@ -347,7 +354,7 @@ def test_concurrent_startups_do_not_collide_on_the_column_upgrade(tmp_path, monk
     assert errors == [], f"a concurrent startup failed: {errors[0]!r}"
 
     columns = {c["name"] for c in inspect(engines[0]).get_columns(timeline_items.name)}
-    assert {"blocks", "schema_version"} <= columns
+    assert COLUMNS_ADDED_SINCE_THE_SQL_LAYER_LANDED <= columns
     for engine in engines:
         engine.dispose()
 

--- a/tests/test_sql_storage.py
+++ b/tests/test_sql_storage.py
@@ -1,4 +1,5 @@
 import json
+import multiprocessing
 import os
 import threading
 from pathlib import Path
@@ -364,3 +365,64 @@ def test_a_real_migration_failure_is_not_swallowed():
     assert _is_duplicate_column(duplicate) is True
     assert _is_duplicate_column(sqlite_duplicate) is True
     assert _is_duplicate_column(unrelated) is False
+
+
+def _boot_one_service(url, queue):
+    """A whole service starting: fresh interpreter, its own engine, its own
+    module state. Must run in a separate *process* -- threads share
+    `_ENGINE_LOCK`, `_SEED_LOCK` and the cached engine, which serializes
+    exactly the steps whose cross-process race this is testing.
+    """
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    os.environ["DATABASE_URL"] = url
+    try:
+        import a2a_store
+        import storage_db
+
+        storage_db.reset_engine_for_tests()
+        storage_db.get_engine()          # create_all
+        a2a_store.list_agents()          # seeds DEFAULT_AGENTS
+        queue.put(None)
+    except BaseException as exc:  # noqa: BLE001 - reported via the queue
+        queue.put(f"{type(exc).__name__}: {str(exc)[:200]}")
+
+
+def test_a_first_deploy_boots_every_service_against_an_empty_database(tmp_path, monkeypatch):
+    """The first deploy: empty database, all four services starting at once.
+
+    Two reflect-then-write races meet here. `create_all` checks which tables
+    exist before creating them, and the DEFAULT_AGENTS seed checks which agents
+    exist before inserting them -- neither check is a lock, and on Postgres
+    (READ COMMITTED) both can be stale by the time the write lands. SQLite
+    hides this because its writers serialize, so it only bites on the
+    production backend.
+    """
+    from storage_db import get_engine, reset_engine_for_tests
+
+    url = os.getenv("TEST_DATABASE_URL") or f"sqlite:///{tmp_path / 'fresh.db'}"
+    monkeypatch.setenv("DATABASE_URL", url)
+
+    # Start from genuinely nothing, the way a newly provisioned database is.
+    reset_engine_for_tests()
+    metadata.drop_all(get_engine())
+    reset_engine_for_tests()
+
+    workers = 4
+    ctx = multiprocessing.get_context("spawn")
+    queue = ctx.Queue()
+    procs = [ctx.Process(target=_boot_one_service, args=(url, queue)) for _ in range(workers)]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+
+    failures = [msg for msg in (queue.get(timeout=30) for _ in range(workers)) if msg]
+    assert failures == [], f"{len(failures)}/{workers} services failed to boot: {failures[0]}"
+
+    reset_engine_for_tests()
+    ids = [agent["id"] for agent in a2a_store.list_agents()]
+    assert len(ids) == len(set(ids)), f"an agent was seeded twice: {ids}"
+    reset_engine_for_tests()

--- a/tests/test_sql_storage.py
+++ b/tests/test_sql_storage.py
@@ -282,3 +282,85 @@ def test_a_database_predating_the_card_columns_is_upgraded_in_place(tmp_path, mo
     assert [a["id"] for a in item["actions"]] == ["approve"]
 
     reset_engine_for_tests()
+
+
+def _make_legacy_table(url):
+    """The timeline_items table as the revision before blocks/schema_version
+    defined it."""
+    from sqlalchemy import Column, MetaData, Table, create_engine
+
+    from storage_db import normalize_database_url, timeline_items
+
+    engine = create_engine(normalize_database_url(url), future=True)
+    legacy = MetaData()
+    Table(
+        timeline_items.name,
+        legacy,
+        *[
+            Column(c.name, c.type, primary_key=c.primary_key, nullable=c.nullable)
+            for c in timeline_items.columns
+            if c.name not in ("blocks", "schema_version")
+        ],
+    )
+    legacy.drop_all(engine)
+    legacy.create_all(engine)
+    engine.dispose()
+    return engine
+
+
+def test_concurrent_startups_do_not_collide_on_the_column_upgrade(tmp_path, monkeypatch):
+    """All four services boot at once against one database.
+
+    The reflection in _add_missing_columns is not a lock, so several callers
+    can decide a column is missing before any of them adds it. Whoever loses
+    that race must not crash -- the column being there is the goal, and it does
+    not matter who created it.
+    """
+    from sqlalchemy import create_engine, inspect
+
+    from storage_db import _add_missing_columns, normalize_database_url, timeline_items
+
+    url = os.getenv("TEST_DATABASE_URL") or f"sqlite:///{tmp_path / 'race.db'}"
+    _make_legacy_table(url)
+
+    # A separate engine per worker, so each reflects the schema independently
+    # -- a shared engine would not reproduce the race.
+    workers = 4
+    engines = [create_engine(normalize_database_url(url), future=True) for _ in range(workers)]
+    barrier = threading.Barrier(workers)
+    errors: List[BaseException] = []
+
+    def boot(engine):
+        try:
+            barrier.wait(timeout=30)
+            _add_missing_columns(engine)
+        except BaseException as exc:  # noqa: BLE001 - re-raised via `errors`
+            errors.append(exc)
+
+    threads = [threading.Thread(target=boot, args=(e,)) for e in engines]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert errors == [], f"a concurrent startup failed: {errors[0]!r}"
+
+    columns = {c["name"] for c in inspect(engines[0]).get_columns(timeline_items.name)}
+    assert {"blocks", "schema_version"} <= columns
+    for engine in engines:
+        engine.dispose()
+
+
+def test_a_real_migration_failure_is_not_swallowed():
+    """The duplicate-column tolerance must not hide a genuinely broken ALTER."""
+    from sqlalchemy.exc import DBAPIError
+
+    from storage_db import _is_duplicate_column
+
+    duplicate = DBAPIError("stmt", {}, Exception('column "blocks" already exists'))
+    sqlite_duplicate = DBAPIError("stmt", {}, Exception("duplicate column name: blocks"))
+    unrelated = DBAPIError("stmt", {}, Exception("permission denied for table timeline_items"))
+
+    assert _is_duplicate_column(duplicate) is True
+    assert _is_duplicate_column(sqlite_duplicate) is True
+    assert _is_duplicate_column(unrelated) is False

--- a/tests/test_timeline_server.py
+++ b/tests/test_timeline_server.py
@@ -336,3 +336,21 @@ def test_a_non_action_patch_is_unaffected(client):
         f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"}
     ).status_code == 200
     assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_dispatched_action_is_exposed_so_a_surface_can_close_the_card(client):
+    """The approval UI greys out a card's buttons the moment it is claimed,
+    rather than waiting for the dispatcher to write processed_action a poll
+    later. That needs the field on every read, including right after create,
+    so a surface never has to treat "missing" and "unclaimed" alike."""
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+    assert item["dispatched_action"] == ""
+
+    approved = client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"}
+    ).json()
+    assert approved["dispatched_action"] == "Approve"
+
+    assert client.get(f"/v1/timeline/items/{item['id']}").json()["dispatched_action"] == "Approve"
+    listed = client.get("/v1/timeline/users/default/items").json()["items"]
+    assert listed[0]["dispatched_action"] == "Approve"

--- a/tests/test_timeline_server.py
+++ b/tests/test_timeline_server.py
@@ -19,6 +19,12 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", url)
     monkeypatch.delenv("TIMELINE_API_TOKEN", raising=False)
     monkeypatch.delenv("TIMELINE_CORS_ORIGINS", raising=False)
+    # enforce_token_policy() runs at import and is fatal on a deployment with
+    # no token. A CI runner inside Kubernetes sets KUBERNETES_SERVICE_HOST, so
+    # without this the reload below raises and the whole suite errors out --
+    # on the runner, not on anyone's laptop.
+    for marker in ("RAILWAY_SERVICE_NAME", "RAILWAY_ENVIRONMENT", "KUBERNETES_SERVICE_HOST"):
+        monkeypatch.delenv(marker, raising=False)
     reset_engine_for_tests()
 
     # A shared Postgres persists across tests; start each one from a clean
@@ -354,3 +360,62 @@ def test_dispatched_action_is_exposed_so_a_surface_can_close_the_card(client):
     assert client.get(f"/v1/timeline/items/{item['id']}").json()["dispatched_action"] == "Approve"
     listed = client.get("/v1/timeline/users/default/items").json()["items"]
     assert listed[0]["dispatched_action"] == "Approve"
+
+
+def test_a_failed_dispatch_leaves_the_card_approvable(client, monkeypatch):
+    """The claim and the dispatch it authorises commit together.
+
+    This is the failure the claim itself introduces: if a claim could outlive
+    a dispatch that never happened, the card would be terminal with nothing
+    executed -- a lost approval, which is harder to notice than a duplicate
+    one. Sharing a transaction means the claim dies with the dispatch.
+    """
+    import timeline_server as server
+
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("A2A write failed")
+
+    monkeypatch.setattr(server, "add_message", explode)
+    with pytest.raises(RuntimeError):
+        client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+
+    # The claim must not have survived the rollback.
+    assert client.get(f"/v1/timeline/items/{item['id']}").json()["dispatched_action"] == ""
+
+    monkeypatch.undo()
+    retry = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+    assert retry.status_code == 200
+    assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_an_ambiguous_action_id_is_refused_rather_than_guessed(client):
+    """A stored card can carry duplicate ids -- reads stay lenient so one bad
+    record cannot break a timeline. Dispatch must not be lenient: picking the
+    first match would execute a different action than the human chose."""
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+
+    # Write duplicates straight to the store, bypassing the strict API check
+    # that stops them being created in the first place.
+    from storage_db import timeline_items, write_connection
+    from sqlalchemy import update as sql_update
+
+    with write_connection() as conn:
+        conn.execute(
+            sql_update(timeline_items)
+            .where(timeline_items.c.id == item["id"])
+            .values(
+                actions=[
+                    {"id": "approve", "label": "Approve Trade", "style": "neutral", "confirm": None},
+                    {"id": "approve", "label": "Approve Refund", "style": "neutral", "confirm": None},
+                ]
+            )
+        )
+
+    response = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+    assert response.status_code == 400
+    assert _dispatch_count(client, item["id"]) == 0
+    # And nothing was claimed, so the card is still recoverable by a surface
+    # that sends an unambiguous action.
+    assert client.get(f"/v1/timeline/items/{item['id']}").json()["dispatched_action"] == ""

--- a/tests/test_timeline_server.py
+++ b/tests/test_timeline_server.py
@@ -121,6 +121,82 @@ def test_action_id_on_a_missing_card_is_404(client):
     assert response.status_code == 404
 
 
+def _dispatched_actions(client):
+    messages = client.get("/v1/a2a/agents/mcp-orchestrator/messages").json()["messages"]
+    return [m["metadata"].get("action") for m in messages if m["type"] == "timeline_action"]
+
+
+def test_bare_action_label_the_card_never_offered_is_refused(client):
+    # The legacy `action` path must be validated too — guarding only
+    # `action_id` would leave this wide open while looking closed.
+    item = _create(client)
+    response = client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action": "Delete Everything"}
+    )
+    assert response.status_code == 400
+    assert _dispatched_actions(client) == []
+
+
+def test_bare_action_label_on_a_card_with_no_actions_is_refused(client):
+    item = _create(client, actions=[])
+    response = client.patch(f"/v1/timeline/items/{item['id']}", json={"action": "Approve"})
+    assert response.status_code == 400
+    assert _dispatched_actions(client) == []
+
+
+def test_action_label_contradicting_action_id_is_refused(client):
+    item = _create(
+        client,
+        actions=[{"id": "approve", "label": "Approve"}, {"id": "reject", "label": "Reject"}],
+    )
+    response = client.patch(
+        f"/v1/timeline/items/{item['id']}",
+        json={"action_id": "approve", "action": "Reject"},
+    )
+    assert response.status_code == 400
+    assert _dispatched_actions(client) == []
+
+
+def test_matching_action_and_action_id_are_accepted(client):
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+    response = client.patch(
+        f"/v1/timeline/items/{item['id']}",
+        json={"action_id": "approve", "action": "Approve"},
+    )
+    assert response.status_code == 200
+    assert _dispatched_actions(client) == ["Approve"]
+
+
+def test_duplicate_action_ids_are_rejected_at_creation(client):
+    response = client.post(
+        "/v1/timeline/items",
+        json={
+            "title": "x",
+            "actions": [
+                {"id": "approve", "label": "Approve Purchase"},
+                {"id": "approve", "label": "Approve Trade"},
+            ],
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_unsafe_link_url_is_rejected_at_creation(client):
+    response = client.post(
+        "/v1/timeline/items",
+        json={
+            "title": "x",
+            "blocks": [
+                {
+                    "type": "links",
+                    "links": [{"label": "click", "url": "javascript:alert(1)"}],
+                }
+            ],
+        },
+    )
+    assert response.status_code == 422
+
+
 # --- auth ------------------------------------------------------------------
 
 

--- a/tests/test_timeline_server.py
+++ b/tests/test_timeline_server.py
@@ -1,0 +1,157 @@
+"""Timeline API behaviour: auth, typed cards, and action resolution.
+
+Each test points the stores at a fresh tmp_path and reloads the modules so
+that module-level store paths pick the new location up.
+"""
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(tmp_path / "timeline.json"))
+    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "a2a.json"))
+    monkeypatch.delenv("TIMELINE_API_TOKEN", raising=False)
+    monkeypatch.delenv("TIMELINE_CORS_ORIGINS", raising=False)
+
+    import a2a_store
+    import timeline_server
+    import timeline_store
+
+    importlib.reload(a2a_store)
+    importlib.reload(timeline_store)
+    importlib.reload(timeline_server)
+    return TestClient(timeline_server.app)
+
+
+def _create(client, **overrides):
+    payload = {"title": "Card", "body": "hello", "actions": ["Approve", "Reject"]}
+    payload.update(overrides)
+    response = client.post("/v1/timeline/items", json=payload)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+# --- typed cards -----------------------------------------------------------
+
+
+def test_legacy_card_round_trips_and_gains_typed_actions(client):
+    item = _create(client)
+    assert item["body"] == "hello"
+    assert [a["id"] for a in item["actions"]] == ["approve", "reject"]
+    assert item["blocks"][0]["text"] == "hello"
+
+
+def test_typed_card_derives_body_from_blocks(client):
+    item = _create(
+        client,
+        body="",
+        blocks=[
+            {"type": "facts", "label": "Order", "facts": [{"key": "Side", "value": "BUY"}]},
+            {"type": "text", "label": "Note", "text": "pending"},
+        ],
+        actions=[{"id": "approve", "label": "Approve", "style": "primary"}],
+    )
+    # `body` stays populated for every reader that predates blocks.
+    assert "Order:\nSide: BUY" in item["body"]
+    assert "Note:\npending" in item["body"]
+    assert item["actions"][0]["style"] == "primary"
+
+
+def test_explicit_body_is_not_overwritten_by_blocks(client):
+    item = _create(
+        client,
+        body="explicit",
+        blocks=[{"type": "text", "text": "derived"}],
+    )
+    assert item["body"] == "explicit"
+
+
+def test_unknown_block_type_is_rejected(client):
+    response = client.post(
+        "/v1/timeline/items",
+        json={"title": "x", "blocks": [{"type": "hologram", "text": "hi"}]},
+    )
+    assert response.status_code == 422
+
+
+# --- action resolution -----------------------------------------------------
+
+
+def test_action_id_resolves_to_the_label_and_dispatches(client):
+    item = _create(
+        client,
+        actions=[{"id": "approve", "label": "Approve Purchase"}],
+    )
+    response = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "approve purchase"
+
+    # The dispatcher must receive the label, not the id — members match on it.
+    messages = client.get("/v1/a2a/agents/mcp-orchestrator/messages").json()["messages"]
+    action_messages = [m for m in messages if m["type"] == "timeline_action"]
+    assert action_messages[0]["metadata"]["action"] == "Approve Purchase"
+
+
+def test_legacy_action_label_still_works(client):
+    item = _create(client)
+    response = client.patch(f"/v1/timeline/items/{item['id']}", json={"action": "Approve"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "approve"
+
+    messages = client.get("/v1/a2a/agents/mcp-orchestrator/messages").json()["messages"]
+    assert messages[0]["metadata"]["action"] == "Approve"
+
+
+def test_action_id_the_card_never_offered_is_refused(client):
+    item = _create(client, actions=[])
+    response = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+    assert response.status_code == 400
+
+    # Nothing may be dispatched for a refused action.
+    messages = client.get("/v1/a2a/agents/mcp-orchestrator/messages").json()["messages"]
+    assert [m for m in messages if m["type"] == "timeline_action"] == []
+
+
+def test_action_id_on_a_missing_card_is_404(client):
+    response = client.patch("/v1/timeline/items/nope", json={"action_id": "approve"})
+    assert response.status_code == 404
+
+
+# --- auth ------------------------------------------------------------------
+
+
+def test_api_is_open_when_no_token_is_configured(client):
+    assert client.get("/v1/timeline/users/default/items").status_code == 200
+
+
+def test_token_is_required_when_configured(client, monkeypatch):
+    monkeypatch.setenv("TIMELINE_API_TOKEN", "s3cret")
+
+    assert client.get("/v1/timeline/users/default/items").status_code == 401
+    assert client.post("/v1/timeline/items", json={"title": "x"}).status_code == 401
+    assert client.patch("/v1/timeline/items/any", json={"action": "Approve"}).status_code == 401
+    assert client.get("/v1/a2a/agents").status_code == 401
+
+    ok = client.get(
+        "/v1/timeline/users/default/items",
+        headers={"Authorization": "Bearer s3cret"},
+    )
+    assert ok.status_code == 200
+
+
+def test_wrong_token_is_rejected(client, monkeypatch):
+    monkeypatch.setenv("TIMELINE_API_TOKEN", "s3cret")
+    response = client.get(
+        "/v1/timeline/users/default/items",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 401
+
+
+def test_health_never_requires_a_token(client, monkeypatch):
+    monkeypatch.setenv("TIMELINE_API_TOKEN", "s3cret")
+    assert client.get("/health").status_code == 200

--- a/tests/test_timeline_server.py
+++ b/tests/test_timeline_server.py
@@ -238,3 +238,101 @@ def test_wrong_token_is_rejected(client, monkeypatch):
 def test_health_never_requires_a_token(client, monkeypatch):
     monkeypatch.setenv("TIMELINE_API_TOKEN", "s3cret")
     assert client.get("/health").status_code == 200
+
+
+# --- approval is single-shot ------------------------------------------------
+
+
+def _dispatch_count(client, item_id):
+    response = client.get("/v1/a2a/agents/mcp-orchestrator/messages")
+    return len(
+        [
+            m
+            for m in response.json()["messages"]
+            if m.get("metadata", {}).get("timeline_item_id") == item_id
+        ]
+    )
+
+
+def test_an_action_dispatches_once_however_many_times_it_is_sent(client):
+    """A card carries its action to a member exactly once.
+
+    Validating that the card offers the action is not enough: every repeat
+    passes that same check. Without a claim, a double-click or a retried
+    request executes the trade again.
+    """
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+
+    first = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+    assert first.status_code == 200
+
+    for _ in range(5):
+        again = client.patch(f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"})
+        assert again.status_code == 409
+        assert "already dispatched" in again.json()["detail"].lower()
+
+    assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_a_second_different_action_cannot_be_dispatched_either(client):
+    """Approve-then-Reject is the same problem wearing a different label: the
+    card is terminal once any action has gone out, so the claim is per card,
+    not per action."""
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"},
+                                    {"id": "reject", "label": "Reject"}])
+
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"}
+    ).status_code == 200
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "reject"}
+    ).status_code == 409
+
+    assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_the_legacy_label_path_is_claimed_too(client):
+    """The bare `action` label path reaches the same dispatch, so it must go
+    through the same claim -- otherwise the guard is trivially bypassed."""
+    item = _create(client, actions=["Approve", "Reject"])
+
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action": "Approve"}
+    ).status_code == 200
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action": "Approve"}
+    ).status_code == 409
+
+    assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_a_rejected_action_never_claims_the_card(client):
+    """A 400 must leave the card approvable. Claiming on a refused action
+    would let anyone burn a card by sending an action it never offered."""
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "nope"}
+    ).status_code == 400
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action": "Not Offered"}
+    ).status_code == 400
+
+    # Still approvable afterwards.
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"}
+    ).status_code == 200
+    assert _dispatch_count(client, item["id"]) == 1
+
+
+def test_a_non_action_patch_is_unaffected(client):
+    """Editing a card must not consume its one dispatch."""
+    item = _create(client, actions=[{"id": "approve", "label": "Approve"}])
+
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"status": "read"}
+    ).status_code == 200
+    assert client.patch(
+        f"/v1/timeline/items/{item['id']}", json={"action_id": "approve"}
+    ).status_code == 200
+    assert _dispatch_count(client, item["id"]) == 1

--- a/tests/test_timeline_startup.py
+++ b/tests/test_timeline_startup.py
@@ -9,10 +9,16 @@ import importlib
 
 import pytest
 
+from storage_db import reset_engine_for_tests
+
 
 def _reload_server(monkeypatch, tmp_path):
-    monkeypatch.setenv("TIMELINE_STORE_PATH", str(tmp_path / "timeline.json"))
-    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "a2a.json"))
+    # TIMELINE_STORE_PATH/A2A_STORE_PATH only feed the JSON->SQL migration
+    # script now; the server reaches its data through DATABASE_URL. Setting
+    # the old paths isolated nothing, so these tests were running against
+    # whatever sits at ~/.xmcp/xmcp.db on the machine.
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'startup.db'}")
+    reset_engine_for_tests()
     import timeline_server
 
     return importlib.reload(timeline_server)

--- a/tests/test_timeline_startup.py
+++ b/tests/test_timeline_startup.py
@@ -1,0 +1,50 @@
+"""The token policy must hold on every entrypoint, not just `main()`.
+
+`main.py` does `from timeline_server import app` for the Railway timeline
+service, so a check that lives only in `timeline_server.main()` never runs
+on the deployment that most needs it.
+"""
+
+import importlib
+
+import pytest
+
+
+def _reload_server(monkeypatch, tmp_path):
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(tmp_path / "timeline.json"))
+    monkeypatch.setenv("A2A_STORE_PATH", str(tmp_path / "a2a.json"))
+    import timeline_server
+
+    return importlib.reload(timeline_server)
+
+
+def test_deployment_without_a_token_refuses_to_start(monkeypatch, tmp_path):
+    monkeypatch.delenv("TIMELINE_API_TOKEN", raising=False)
+    monkeypatch.delenv("TIMELINE_ALLOW_INSECURE", raising=False)
+    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "timeline-server")
+
+    with pytest.raises(RuntimeError, match="TIMELINE_API_TOKEN"):
+        _reload_server(monkeypatch, tmp_path)
+
+
+def test_deployment_with_a_token_starts(monkeypatch, tmp_path):
+    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "timeline-server")
+    monkeypatch.setenv("TIMELINE_API_TOKEN", "s3cret")
+    assert _reload_server(monkeypatch, tmp_path).app is not None
+
+
+def test_deployment_can_opt_out_explicitly(monkeypatch, tmp_path):
+    monkeypatch.delenv("TIMELINE_API_TOKEN", raising=False)
+    monkeypatch.setenv("RAILWAY_SERVICE_NAME", "timeline-server")
+    monkeypatch.setenv("TIMELINE_ALLOW_INSECURE", "1")
+    assert _reload_server(monkeypatch, tmp_path).app is not None
+
+
+def test_local_run_without_a_token_only_warns(monkeypatch, tmp_path, capsys):
+    for marker in ("RAILWAY_SERVICE_NAME", "RAILWAY_ENVIRONMENT", "KUBERNETES_SERVICE_HOST"):
+        monkeypatch.delenv(marker, raising=False)
+    monkeypatch.delenv("TIMELINE_API_TOKEN", raising=False)
+    monkeypatch.delenv("TIMELINE_ALLOW_INSECURE", raising=False)
+
+    assert _reload_server(monkeypatch, tmp_path).app is not None
+    assert "WARNING: TIMELINE_API_TOKEN is not set" in capsys.readouterr().out

--- a/tests/test_timeline_store.py
+++ b/tests/test_timeline_store.py
@@ -1,0 +1,96 @@
+"""Storage-level guarantees: cross-process safety and legacy readability."""
+
+import importlib
+import json
+import multiprocessing
+import os
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("TIMELINE_STORE_PATH", str(tmp_path / "timeline.json"))
+    import timeline_store
+
+    importlib.reload(timeline_store)
+    return timeline_store
+
+
+def _writer(store_path: str, count: int, tag: str) -> None:
+    """Runs in a separate process: reload the module so it binds the shared
+    store path, then append cards."""
+    os.environ["TIMELINE_STORE_PATH"] = store_path
+    import timeline_store
+
+    importlib.reload(timeline_store)
+    for i in range(count):
+        timeline_store.add_item({"title": f"{tag}-{i}", "body": "x"})
+
+
+def test_concurrent_processes_do_not_lose_items(tmp_path):
+    store_path = str(tmp_path / "timeline.json")
+    per_writer = 25
+    writers = 4
+
+    ctx = multiprocessing.get_context("spawn")
+    procs = [
+        ctx.Process(target=_writer, args=(store_path, per_writer, f"w{n}"))
+        for n in range(writers)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=60)
+        assert proc.exitcode == 0
+
+    data = json.loads(open(store_path, encoding="utf-8").read())
+    assert len(data["items"]) == per_writer * writers
+    # Every writer's cards survived, not just the last one to win a race.
+    titles = {item["title"] for item in data["items"]}
+    assert len(titles) == per_writer * writers
+
+
+def test_legacy_records_on_disk_are_still_readable(store, tmp_path):
+    # Simulate a store written before typed cards existed.
+    legacy = {
+        "items": [
+            {
+                "id": "old-1",
+                "user_id": "default",
+                "title": "Legacy card",
+                "body": "BUY 10 $TSLA",
+                "status": "unread",
+                "posted_by": "tradedesk",
+                "actions": ["Approve", "Reject"],
+                "metadata": {"agent_id": "tradedesk"},
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "updated_at": None,
+            }
+        ]
+    }
+    (tmp_path / "timeline.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    item = store.get_item("old-1")
+    assert item["blocks"] == [{"type": "text", "label": None, "text": "BUY 10 $TSLA"}]
+    assert [a["label"] for a in item["actions"]] == ["Approve", "Reject"]
+    assert [a["id"] for a in item["actions"]] == ["approve", "reject"]
+
+    listed = store.list_items("default")
+    assert len(listed) == 1
+    assert listed[0]["blocks"][0]["text"] == "BUY 10 $TSLA"
+
+
+def test_updating_blocks_keeps_the_derived_body_in_step(store):
+    item = store.add_item({"title": "t", "blocks": [{"type": "text", "text": "before"}]})
+    assert item["body"] == "before"
+
+    updated = store.update_item(item["id"], {"blocks": [{"type": "text", "text": "after"}]})
+    assert updated["body"] == "after"
+
+
+def test_metadata_updates_merge_rather_than_replace(store):
+    item = store.add_item({"title": "t", "body": "b", "metadata": {"agent_id": "tradedesk"}})
+    updated = store.update_item(item["id"], {"metadata": {"processed_action": "Approve"}})
+    assert updated["metadata"]["agent_id"] == "tradedesk"
+    assert updated["metadata"]["processed_action"] == "Approve"

--- a/tests/test_timeline_store.py
+++ b/tests/test_timeline_store.py
@@ -102,3 +102,42 @@ def test_metadata_updates_merge_rather_than_replace(store):
     updated = store.update_item(item["id"], {"metadata": {"processed_action": "Approve"}})
     assert updated["metadata"]["agent_id"] == "tradedesk"
     assert updated["metadata"]["processed_action"] == "Approve"
+
+
+def test_only_one_of_many_concurrent_claims_wins(store):
+    """`claim_action` is the whole single-shot guarantee, so it is worth
+    testing at the store level and not only through the API."""
+    import threading
+
+    item = store.add_item({"title": "t", "body": "b", "actions": ["Approve"]})
+
+    workers = 8
+    barrier = threading.Barrier(workers)
+    results = []
+    lock = threading.Lock()
+
+    def claim():
+        barrier.wait(timeout=30)
+        won = store.claim_action(item["id"], "Approve")
+        with lock:
+            results.append(won)
+
+    threads = [threading.Thread(target=claim) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert results.count(True) == 1, f"expected exactly one winner, got {results}"
+    assert store.get_item(item["id"])["dispatched_action"] == "Approve"
+
+
+def test_a_claim_is_per_card_not_per_action(store):
+    item = store.add_item({"title": "t", "body": "b", "actions": ["Approve", "Reject"]})
+    assert store.claim_action(item["id"], "Approve") is True
+    # A different action on an already-dispatched card must not get through.
+    assert store.claim_action(item["id"], "Reject") is False
+
+
+def test_claiming_a_card_that_does_not_exist_fails_rather_than_raising(store):
+    assert store.claim_action("no-such-card", "Approve") is False

--- a/tests/test_tradedesk.py
+++ b/tests/test_tradedesk.py
@@ -40,9 +40,13 @@ def test_mention_creates_approval_card(tmp_path, monkeypatch):
         MentionContext(text="@Tradedesk $TSLA buy 10", mention_id=1, author_id=2)
     )
     assert "pending human approval" in reply.text.lower()
-    # Labels are the compatibility surface: execute_action() matches on them,
-    # so they must stay "Approve"/"Reject" even though actions are now typed.
-    assert [a["label"] for a in reply.card["actions"]] == ["Approve", "Reject"]
+    # Both halves matter: execute_action() matches on the label, and the
+    # approval UI dispatches on the id, so a regression in either breaks a
+    # different half of the round trip.
+    assert [(a["id"], a["label"]) for a in reply.card["actions"]] == [
+        ("approve", "Approve"),
+        ("reject", "Reject"),
+    ]
     meta = reply.card["metadata"]
     assert meta["agent_id"] == "tradedesk"
     assert meta["ticker"] == "TSLA"

--- a/tests/test_tradedesk.py
+++ b/tests/test_tradedesk.py
@@ -40,7 +40,9 @@ def test_mention_creates_approval_card(tmp_path, monkeypatch):
         MentionContext(text="@Tradedesk $TSLA buy 10", mention_id=1, author_id=2)
     )
     assert "pending human approval" in reply.text.lower()
-    assert reply.card["actions"] == ["Approve", "Reject"]
+    # Labels are the compatibility surface: execute_action() matches on them,
+    # so they must stay "Approve"/"Reject" even though actions are now typed.
+    assert [a["label"] for a in reply.card["actions"]] == ["Approve", "Reject"]
     meta = reply.card["metadata"]
     assert meta["agent_id"] == "tradedesk"
     assert meta["ticker"] == "TSLA"

--- a/timeline_server.py
+++ b/timeline_server.py
@@ -10,7 +10,15 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from a2a_store import add_message, get_agent, list_agents, list_messages, register_agent
 from cards import Block, CardAction, DuplicateActionIdError, normalize_actions, resolve_action
-from timeline_store import add_item, delete_item, get_item, list_items, update_item
+from timeline_store import (
+    add_item,
+    claim_action,
+    delete_item,
+    get_item,
+    list_items,
+    release_action_claim,
+    update_item,
+)
 
 app = FastAPI(title="xMCP Timeline Service")
 
@@ -228,14 +236,37 @@ def patch_item(item_id: str, updates: TimelineItemUpdate) -> Dict[str, Any]:
 
         data["action"] = action
 
+        # Claim before anything is written or dispatched. Validating that the
+        # card offers the action does not make approval single-shot -- every
+        # concurrent caller passes that same check -- so without this a
+        # double-click, two surfaces, or a retried request each dispatch the
+        # action again, and the member executes the trade once per request.
+        if not claim_action(item_id, action):
+            current = get_item(item_id) or {}
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Card already dispatched "
+                    f"'{current.get('dispatched_action') or 'an action'}'"
+                ),
+            )
+
     if action and not updates.status:
         data["status"] = action.lower()
 
     item = update_item(item_id, data)
     if not item:
+        if action:
+            release_action_claim(item_id)
         raise HTTPException(status_code=404, detail="Item not found")
     if action:
-        _dispatch_action(item, action)
+        try:
+            _dispatch_action(item, action)
+        except Exception:
+            # The claim exists to stop a second dispatch, not to make a card
+            # that never dispatched permanently unapprovable.
+            release_action_claim(item_id)
+            raise
     return item
 
 

--- a/timeline_server.py
+++ b/timeline_server.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ConfigDict, Field
 
 from a2a_store import add_message, get_agent, list_agents, list_messages, register_agent
-from cards import Block, CardAction, resolve_action
+from cards import Block, CardAction, DuplicateActionIdError, normalize_actions, resolve_action
 from timeline_store import add_item, delete_item, get_item, list_items, update_item
 
 app = FastAPI(title="xMCP Timeline Service")
@@ -26,12 +26,57 @@ def _cors_origins() -> List[str]:
 # needed when a surface is hosted separately. Default to allowing none.
 _origins = _cors_origins()
 if _origins:
+    # No allow_credentials: this API authenticates with a bearer header, not
+    # cookies, so enabling credentialed CORS would widen exposure for nothing.
+    # Methods and headers are enumerated rather than wildcarded.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type"],
+    )
+
+
+# Environment variables that indicate this process is a deployment rather
+# than someone's laptop. On a deployment an empty token is fatal, not a
+# warning — this API includes the PATCH that authorizes agent actions.
+_DEPLOY_MARKERS = ("RAILWAY_SERVICE_NAME", "RAILWAY_ENVIRONMENT", "KUBERNETES_SERVICE_HOST")
+
+
+def _is_deployment() -> bool:
+    return any(os.getenv(marker, "").strip() for marker in _DEPLOY_MARKERS)
+
+
+def enforce_token_policy() -> None:
+    """Refuse to serve approval routes anonymously on a deployment.
+
+    Called at import time so it applies to *every* entrypoint — including
+    `uvicorn main:app`, which imports `timeline_server.app` directly and
+    never runs `main()`. Putting this check only in `main()` would leave
+    the Railway path (main.py: `from timeline_server import app`) silently
+    unauthenticated, which is the one deployment that most needs it.
+
+    Local development stays frictionless: with no deployment marker set,
+    an empty token only warns. `TIMELINE_ALLOW_INSECURE=1` is the explicit
+    escape hatch for deliberately running a deployment open."""
+    if os.getenv("TIMELINE_API_TOKEN", "").strip():
+        return
+
+    if _is_deployment() and os.getenv("TIMELINE_ALLOW_INSECURE", "").strip() != "1":
+        raise RuntimeError(
+            "TIMELINE_API_TOKEN is not set but this looks like a deployment "
+            f"({', '.join(m for m in _DEPLOY_MARKERS if os.getenv(m, '').strip())}). "
+            "The /v1 approval endpoints authorize agent actions and would be "
+            "reachable anonymously. Set TIMELINE_API_TOKEN, or set "
+            "TIMELINE_ALLOW_INSECURE=1 to override deliberately."
+        )
+
+    print(
+        "WARNING: TIMELINE_API_TOKEN is not set — the timeline and A2A API "
+        "are unauthenticated. Anyone who can reach this port can approve "
+        "agent actions. Set it before exposing this service.",
+        flush=True,
     )
 
 
@@ -41,16 +86,17 @@ def require_token(authorization: Optional[str] = Header(None)) -> None:
     Read from the environment per request rather than at import time so
     tests (and a restarted process) see the current value.
 
-    When TIMELINE_API_TOKEN is unset the API stays open, which keeps local
-    `make run` working — but this endpoint set includes the approval PATCH
-    that authorizes agent actions, so an exposed deployment must set it.
-    `main()` warns loudly when it is missing."""
+    When TIMELINE_API_TOKEN is unset the API stays open for local use;
+    `enforce_token_policy()` makes that state fatal on a deployment."""
     expected = os.getenv("TIMELINE_API_TOKEN", "").strip()
     if not expected:
         return
     presented = authorization or ""
     if not secrets.compare_digest(presented, f"Bearer {expected}"):
         raise HTTPException(status_code=401, detail="Missing or invalid bearer token")
+
+
+enforce_token_policy()
 
 
 # /health deliberately stays outside this router: container and load-balancer
@@ -129,8 +175,15 @@ def get_item_by_id(item_id: str) -> Dict[str, Any]:
 
 @v1.post("/timeline/items")
 def create_item(payload: TimelineItemCreate) -> Dict[str, Any]:
-    item = add_item(payload.model_dump())
-    return item
+    data = payload.model_dump()
+    # Reject duplicate action ids before the card is stored: once persisted,
+    # resolve_action would silently pick the first match and the later button
+    # would be unreachable.
+    try:
+        normalize_actions(data.get("actions"), strict=True)
+    except DuplicateActionIdError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return add_item(data)
 
 
 @v1.patch("/timeline/items/{item_id}")
@@ -138,18 +191,41 @@ def patch_item(item_id: str, updates: TimelineItemUpdate) -> Dict[str, Any]:
     data = updates.model_dump(exclude_unset=True)
     action = updates.action
 
-    if updates.action_id and not action:
+    # Every dispatched action must be one the card actually offers — on BOTH
+    # paths. Validating only `action_id` would leave the legacy `action` label
+    # path able to dispatch anything, which is worse than no guard at all
+    # because the tests would make the endpoint look closed.
+    if updates.action_id or action:
         current = get_item(item_id)
         if not current:
             raise HTTPException(status_code=404, detail="Item not found")
-        action = resolve_action(current, updates.action_id)
-        # Fail closed: a surface must not be able to trigger an action the
-        # card never offered.
-        if not action:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Card has no action '{updates.action_id}'",
-            )
+
+        if updates.action_id:
+            resolved = resolve_action(current, updates.action_id)
+            if not resolved:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Card has no action '{updates.action_id}'",
+                )
+            # A caller may send both; they must agree, or we cannot know
+            # which one the human actually chose.
+            if action and action != resolved:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"action '{action}' does not match action_id "
+                        f"'{updates.action_id}' (which resolves to '{resolved}')"
+                    ),
+                )
+            action = resolved
+        else:
+            offered = {a.get("label") for a in current.get("actions") or []}
+            if action not in offered:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Card does not offer action '{action}'",
+                )
+
         data["action"] = action
 
     if action and not updates.status:
@@ -231,13 +307,8 @@ def main() -> None:
     host = os.getenv("TIMELINE_HOST", "0.0.0.0")
     port_value = os.getenv("PORT") or os.getenv("TIMELINE_PORT", "8080")
     port = int(port_value)
-    if not os.getenv("TIMELINE_API_TOKEN", "").strip():
-        print(
-            "WARNING: TIMELINE_API_TOKEN is not set — the timeline and A2A API "
-            "are unauthenticated. Anyone who can reach this port can approve "
-            "agent actions. Set it before exposing this service.",
-            flush=True,
-        )
+    # The token policy is enforced at import time (see enforce_token_policy),
+    # so it has already run for every entrypoint by the time we get here.
     import uvicorn
 
     uvicorn.run(app, host=host, port=port)

--- a/timeline_server.py
+++ b/timeline_server.py
@@ -67,7 +67,16 @@ def enforce_token_policy() -> None:
 
     Local development stays frictionless: with no deployment marker set,
     an empty token only warns. `TIMELINE_ALLOW_INSECURE=1` is the explicit
-    escape hatch for deliberately running a deployment open."""
+    escape hatch for deliberately running a deployment open.
+
+    KNOWN GAP: this is a heuristic, and it only recognises Railway and
+    Kubernetes. A VPS, Fly, Render, or a bare `docker compose` on a public
+    host sets none of these markers, so an empty token there warns instead of
+    refusing -- and the approval API is reachable anonymously. Fixing that
+    properly means inverting the default (always fatal, opt out explicitly
+    for local), which trades a silent gap for a one-time startup error on a
+    fresh checkout. That trade is a product call, so it is deliberately left
+    open rather than made here; see the PR discussion."""
     if os.getenv("TIMELINE_API_TOKEN", "").strip():
         return
 

--- a/timeline_server.py
+++ b/timeline_server.py
@@ -10,13 +10,13 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from a2a_store import add_message, get_agent, list_agents, list_messages, register_agent
 from cards import Block, CardAction, DuplicateActionIdError, normalize_actions, resolve_action
+from storage_db import write_connection
 from timeline_store import (
     add_item,
     claim_action,
     delete_item,
     get_item,
     list_items,
-    release_action_claim,
     update_item,
 )
 
@@ -234,39 +234,48 @@ def patch_item(item_id: str, updates: TimelineItemUpdate) -> Dict[str, Any]:
                     detail=f"Card does not offer action '{action}'",
                 )
 
-        data["action"] = action
+        # `action` is deliberately not written into `data`: update_item does
+        # not persist it, and the dispatched action is recorded by the claim
+        # as `dispatched_action`. Assigning it here only looked like storage.
 
-        # Claim before anything is written or dispatched. Validating that the
-        # card offers the action does not make approval single-shot -- every
-        # concurrent caller passes that same check -- so without this a
-        # double-click, two surfaces, or a retried request each dispatch the
-        # action again, and the member executes the trade once per request.
-        if not claim_action(item_id, action):
-            current = get_item(item_id) or {}
+        # Claim and dispatch in ONE transaction. Validating that the card
+        # offers the action does not make approval single-shot -- every
+        # concurrent caller passes that same check -- so without a claim a
+        # double-click, two surfaces, or a retried request each dispatch
+        # again and the member executes the trade once per request.
+        #
+        # They commit together deliberately. A claim taken in its own
+        # transaction turns a duplicate-dispatch bug into a lost-dispatch
+        # one: kill the process in the gap and the card is claimed with
+        # nothing dispatched -- terminal, unrecoverable, and silent until a
+        # human asks why the trade never happened. Sharing the transaction
+        # means a crash rolls back both and the card stays approvable.
+        if not updates.status:
+            data["status"] = action.lower()
+        # The dispatched message carries the status the action produces, which
+        # is what it had before this endpoint started writing it separately.
+        dispatched_card = {**current, "status": data.get("status", current.get("status"))}
+
+        with write_connection() as conn:
+            claimed = claim_action(item_id, action, conn=conn)
+            if claimed:
+                _dispatch_action(dispatched_card, action, conn=conn)
+
+        # Raised outside the transaction: reading the card needs its own
+        # connection, and taking one while holding a write lock is how SQLite
+        # deadlocks.
+        if not claimed:
+            already = (get_item(item_id) or {}).get("dispatched_action")
             raise HTTPException(
                 status_code=409,
-                detail=(
-                    f"Card already dispatched "
-                    f"'{current.get('dispatched_action') or 'an action'}'"
-                ),
+                detail=f"Card already dispatched '{already or 'an action'}'",
             )
 
-    if action and not updates.status:
-        data["status"] = action.lower()
-
+    # The dispatch has already been recorded above; this only reflects the
+    # action in the card's own fields, so a failure here cannot lose it.
     item = update_item(item_id, data)
     if not item:
-        if action:
-            release_action_claim(item_id)
         raise HTTPException(status_code=404, detail="Item not found")
-    if action:
-        try:
-            _dispatch_action(item, action)
-        except Exception:
-            # The claim exists to stop a second dispatch, not to make a card
-            # that never dispatched permanently unapprovable.
-            release_action_claim(item_id)
-            raise
     return item
 
 
@@ -317,7 +326,7 @@ if UI_DIR.is_dir():
     app.mount("/ui", StaticFiles(directory=str(UI_DIR), html=True), name="ui")
 
 
-def _dispatch_action(item: Dict[str, Any], action: str) -> None:
+def _dispatch_action(item: Dict[str, Any], action: str, *, conn=None) -> None:
     target_agent = os.getenv("TIMELINE_ACTION_AGENT", "mcp-orchestrator")
     add_message(
         {
@@ -330,7 +339,8 @@ def _dispatch_action(item: Dict[str, Any], action: str) -> None:
                 "action": action,
                 "status": item.get("status"),
             },
-        }
+        },
+        conn=conn,
     )
 
 

--- a/timeline_server.py
+++ b/timeline_server.py
@@ -1,13 +1,61 @@
 import os
-from typing import Any, Dict, List, Literal, Optional
+import secrets
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Union
 
-from fastapi import FastAPI, HTTPException
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ConfigDict, Field
 
 from a2a_store import add_message, get_agent, list_agents, list_messages, register_agent
+from cards import Block, CardAction, resolve_action
 from timeline_store import add_item, delete_item, get_item, list_items, update_item
 
 app = FastAPI(title="xMCP Timeline Service")
+
+UI_DIR = Path(__file__).resolve().parent / "ui"
+
+
+def _cors_origins() -> List[str]:
+    raw = os.getenv("TIMELINE_CORS_ORIGINS", "")
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+# The bundled UI is served by this same app, so cross-origin access is only
+# needed when a surface is hosted separately. Default to allowing none.
+_origins = _cors_origins()
+if _origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def require_token(authorization: Optional[str] = Header(None)) -> None:
+    """Guard every /v1 route with a shared bearer token.
+
+    Read from the environment per request rather than at import time so
+    tests (and a restarted process) see the current value.
+
+    When TIMELINE_API_TOKEN is unset the API stays open, which keeps local
+    `make run` working — but this endpoint set includes the approval PATCH
+    that authorizes agent actions, so an exposed deployment must set it.
+    `main()` warns loudly when it is missing."""
+    expected = os.getenv("TIMELINE_API_TOKEN", "").strip()
+    if not expected:
+        return
+    presented = authorization or ""
+    if not secrets.compare_digest(presented, f"Bearer {expected}"):
+        raise HTTPException(status_code=401, detail="Missing or invalid bearer token")
+
+
+# /health deliberately stays outside this router: container and load-balancer
+# probes must not need a credential.
+v1 = APIRouter(prefix="/v1", dependencies=[Depends(require_token)])
 
 
 @app.get("/health")
@@ -19,19 +67,28 @@ class TimelineItemCreate(BaseModel):
     user_id: str = "default"
     title: str
     body: str = ""
+    # Typed content. `body` is derived from these when it isn't supplied,
+    # so older readers keep working either way.
+    blocks: List[Block] = Field(default_factory=list)
     status: str = "unread"
     posted_by: str = "agent"
-    actions: List[str] = Field(default_factory=list)
+    # Accepts legacy ["Approve", "Reject"] as well as typed actions.
+    actions: List[Union[str, CardAction]] = Field(default_factory=list)
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class TimelineItemUpdate(BaseModel):
     status: Optional[str] = None
+    # The human-readable action label. Team members match on this, so it
+    # stays the value that reaches the dispatcher.
     action: Optional[str] = None
+    # The machine id a surface posts; resolved to `action` server-side.
+    action_id: Optional[str] = None
     posted_by: Optional[str] = None
     title: Optional[str] = None
     body: Optional[str] = None
-    actions: Optional[List[str]] = None
+    blocks: Optional[List[Block]] = None
+    actions: Optional[List[Union[str, CardAction]]] = None
     metadata: Optional[Dict[str, Any]] = None
 
 
@@ -56,13 +113,13 @@ class A2AMessageCreate(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
-@app.get("/v1/timeline/users/{user_id}/items")
+@v1.get("/timeline/users/{user_id}/items")
 def get_items(user_id: str, status: Optional[str] = None) -> Dict[str, Any]:
     items = list_items(user_id, status)
     return {"items": items, "count": len(items)}
 
 
-@app.get("/v1/timeline/items/{item_id}")
+@v1.get("/timeline/items/{item_id}")
 def get_item_by_id(item_id: str) -> Dict[str, Any]:
     item = get_item(item_id)
     if not item:
@@ -70,26 +127,43 @@ def get_item_by_id(item_id: str) -> Dict[str, Any]:
     return item
 
 
-@app.post("/v1/timeline/items")
+@v1.post("/timeline/items")
 def create_item(payload: TimelineItemCreate) -> Dict[str, Any]:
     item = add_item(payload.model_dump())
     return item
 
 
-@app.patch("/v1/timeline/items/{item_id}")
+@v1.patch("/timeline/items/{item_id}")
 def patch_item(item_id: str, updates: TimelineItemUpdate) -> Dict[str, Any]:
     data = updates.model_dump(exclude_unset=True)
-    if updates.action and not updates.status:
-        data["status"] = updates.action.lower()
+    action = updates.action
+
+    if updates.action_id and not action:
+        current = get_item(item_id)
+        if not current:
+            raise HTTPException(status_code=404, detail="Item not found")
+        action = resolve_action(current, updates.action_id)
+        # Fail closed: a surface must not be able to trigger an action the
+        # card never offered.
+        if not action:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Card has no action '{updates.action_id}'",
+            )
+        data["action"] = action
+
+    if action and not updates.status:
+        data["status"] = action.lower()
+
     item = update_item(item_id, data)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
-    if updates.action:
-        _dispatch_action(item, updates.action)
+    if action:
+        _dispatch_action(item, action)
     return item
 
 
-@app.delete("/v1/timeline/items/{item_id}")
+@v1.delete("/timeline/items/{item_id}")
 def remove_item(item_id: str) -> Dict[str, Any]:
     deleted = delete_item(item_id)
     if not deleted:
@@ -97,13 +171,13 @@ def remove_item(item_id: str) -> Dict[str, Any]:
     return {"deleted": True, "id": item_id}
 
 
-@app.get("/v1/a2a/agents")
+@v1.get("/a2a/agents")
 def get_agents() -> Dict[str, Any]:
     agents = list_agents()
     return {"agents": agents, "count": len(agents)}
 
 
-@app.get("/v1/a2a/agents/{agent_id}")
+@v1.get("/a2a/agents/{agent_id}")
 def get_agent_by_id(agent_id: str) -> Dict[str, Any]:
     agent = get_agent(agent_id)
     if not agent:
@@ -111,22 +185,29 @@ def get_agent_by_id(agent_id: str) -> Dict[str, Any]:
     return agent
 
 
-@app.post("/v1/a2a/agents")
+@v1.post("/a2a/agents")
 def create_agent(payload: AgentCreate) -> Dict[str, Any]:
     agent = register_agent(payload.model_dump(exclude_unset=True))
     return agent
 
 
-@app.get("/v1/a2a/agents/{agent_id}/messages")
+@v1.get("/a2a/agents/{agent_id}/messages")
 def get_agent_messages(agent_id: str) -> Dict[str, Any]:
     messages = list_messages(agent_id)
     return {"messages": messages, "count": len(messages)}
 
 
-@app.post("/v1/a2a/messages")
+@v1.post("/a2a/messages")
 def create_message(payload: A2AMessageCreate) -> Dict[str, Any]:
     message = add_message(payload.model_dump(by_alias=True))
     return message
+
+
+app.include_router(v1)
+
+# Mounted last so it can never shadow an API route.
+if UI_DIR.is_dir():
+    app.mount("/ui", StaticFiles(directory=str(UI_DIR), html=True), name="ui")
 
 
 def _dispatch_action(item: Dict[str, Any], action: str) -> None:
@@ -150,6 +231,13 @@ def main() -> None:
     host = os.getenv("TIMELINE_HOST", "0.0.0.0")
     port_value = os.getenv("PORT") or os.getenv("TIMELINE_PORT", "8080")
     port = int(port_value)
+    if not os.getenv("TIMELINE_API_TOKEN", "").strip():
+        print(
+            "WARNING: TIMELINE_API_TOKEN is not set — the timeline and A2A API "
+            "are unauthenticated. Anyone who can reach this port can approve "
+            "agent actions. Set it before exposing this service.",
+            flush=True,
+        )
     import uvicorn
 
     uvicorn.run(app, host=host, port=port)

--- a/timeline_store.py
+++ b/timeline_store.py
@@ -1,13 +1,14 @@
 import json
 import os
-import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from cards import SCHEMA_VERSION, derive_body, normalize_actions, normalize_card
+from store_lock import file_lock
+
 STORE_PATH = Path(os.getenv("TIMELINE_STORE_PATH", "~/.xmcp/timeline_store.json")).expanduser()
-STORE_LOCK = threading.Lock()
 
 
 def _utc_now() -> str:
@@ -34,51 +35,63 @@ def _read_store() -> Dict[str, Any]:
 
 
 def _write_store(data: Dict[str, Any]) -> None:
+    """Atomic replace so a mid-write crash can't truncate the timeline."""
     STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    STORE_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp = STORE_PATH.with_suffix(STORE_PATH.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.replace(tmp, STORE_PATH)
 
 
 def list_items(user_id: str, status: Optional[str] = None) -> List[Dict[str, Any]]:
-    with STORE_LOCK:
+    with file_lock(STORE_PATH):
         data = _read_store()
         items = [item for item in data["items"] if item.get("user_id") == user_id]
         if status:
             items = [item for item in items if item.get("status") == status]
-        return items
+        return [normalize_card(item) for item in items]
 
 
 def get_item(item_id: str) -> Optional[Dict[str, Any]]:
-    with STORE_LOCK:
+    with file_lock(STORE_PATH):
         data = _read_store()
         for item in data["items"]:
             if item.get("id") == item_id:
-                return item
+                return normalize_card(item)
     return None
 
 
 def add_item(payload: Dict[str, Any]) -> Dict[str, Any]:
+    blocks = payload.get("blocks") or []
+    # `body` stays authoritative for every older reader, so derive it from
+    # blocks when the caller didn't supply one itself.
+    body = payload.get("body") or ""
+    if blocks and not body:
+        body = derive_body(blocks)
+
     item = {
         "id": payload.get("id") or str(uuid.uuid4()),
         "user_id": payload.get("user_id", "default"),
         "title": payload.get("title", "Untitled"),
-        "body": payload.get("body", ""),
+        "body": body,
+        "blocks": blocks,
+        "schema_version": payload.get("schema_version") or SCHEMA_VERSION,
         "status": payload.get("status", "unread"),
         "posted_by": payload.get("posted_by", "agent"),
-        "actions": payload.get("actions", []),
+        "actions": normalize_actions(payload.get("actions")),
         "metadata": payload.get("metadata", {}),
         "created_at": _utc_now(),
         "updated_at": None,
     }
 
-    with STORE_LOCK:
+    with file_lock(STORE_PATH):
         data = _read_store()
         data["items"].insert(0, item)
         _write_store(data)
-    return item
+    return normalize_card(item)
 
 
 def update_item(item_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    with STORE_LOCK:
+    with file_lock(STORE_PATH):
         data = _read_store()
         for item in data["items"]:
             if item.get("id") != item_id:
@@ -89,15 +102,21 @@ def update_item(item_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any
             if "metadata" in updates and isinstance(updates["metadata"], dict):
                 item["metadata"] = {**item.get("metadata", {}), **updates["metadata"]}
             if "actions" in updates and isinstance(updates["actions"], list):
-                item["actions"] = updates["actions"]
+                item["actions"] = normalize_actions(updates["actions"])
+            if "blocks" in updates and isinstance(updates["blocks"], list):
+                item["blocks"] = updates["blocks"]
+                # Keep the derived text form in step with the blocks unless
+                # the caller overrode `body` in the same update.
+                if "body" not in updates or updates["body"] is None:
+                    item["body"] = derive_body(updates["blocks"])
             item["updated_at"] = _utc_now()
             _write_store(data)
-            return item
+            return normalize_card(item)
     return None
 
 
 def delete_item(item_id: str) -> bool:
-    with STORE_LOCK:
+    with file_lock(STORE_PATH):
         data = _read_store()
         original = len(data["items"])
         data["items"] = [item for item in data["items"] if item.get("id") != item_id]

--- a/timeline_store.py
+++ b/timeline_store.py
@@ -50,6 +50,10 @@ def add_item(payload: Dict[str, Any]) -> Dict[str, Any]:
         "body": body,
         "blocks": blocks,
         "schema_version": payload.get("schema_version") or SCHEMA_VERSION,
+        # Always present, so a surface can read it uniformly instead of having
+        # to treat "missing" and "unclaimed" as the same thing. A new card has
+        # dispatched nothing; only claim_action sets this.
+        "dispatched_action": "",
         "status": payload.get("status", "unread"),
         "posted_by": payload.get("posted_by", "agent"),
         "actions": normalize_actions(payload.get("actions")),

--- a/timeline_store.py
+++ b/timeline_store.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import delete, insert, select, update
+from sqlalchemy.engine import Connection
 
 from cards import SCHEMA_VERSION, derive_body, normalize_actions, normalize_card
 from storage_db import (
@@ -119,7 +120,7 @@ def delete_item(item_id: str) -> bool:
         return result.rowcount > 0
 
 
-def claim_action(item_id: str, action: str) -> bool:
+def claim_action(item_id: str, action: str, *, conn: Optional[Connection] = None) -> bool:
     """Claim this card's one dispatch, atomically. True only for the winner.
 
     Approval is single-shot: a card carries an action to a member exactly
@@ -133,28 +134,21 @@ def claim_action(item_id: str, action: str) -> bool:
     succeed for one caller, whatever the interleaving, and it holds across
     processes -- which matters because several timeline-server replicas may
     serve the same card.
+
+    Pass `conn` to run inside a caller's transaction. The approval path does,
+    so the claim and the dispatch it authorises commit together. Claiming in
+    its own transaction would mean a process killed in the gap -- SIGKILL, an
+    OOM, a container rolling -- leaves a card claimed with nothing dispatched:
+    terminal, unrecoverable, and silent, which is worse than the duplicate
+    dispatch the claim exists to prevent.
     """
-    with write_connection() as conn:
-        result = conn.execute(
-            update(timeline_items)
-            .where(timeline_items.c.id == item_id)
-            .where(timeline_items.c.dispatched_action == "")
-            .values(dispatched_action=action, updated_at=utc_now())
-        )
-        return result.rowcount == 1
-
-
-def release_action_claim(item_id: str) -> None:
-    """Undo a claim whose dispatch never happened.
-
-    Dispatch can fail after the claim is taken (the A2A write throws). Left
-    alone, that card would be permanently unapprovable -- terminal without
-    anything having run. Releasing keeps a failed approval retryable, which
-    is the same rule the dispatcher already follows for failed execution.
-    """
-    with write_connection() as conn:
-        conn.execute(
-            update(timeline_items)
-            .where(timeline_items.c.id == item_id)
-            .values(dispatched_action="")
-        )
+    statement = (
+        update(timeline_items)
+        .where(timeline_items.c.id == item_id)
+        .where(timeline_items.c.dispatched_action == "")
+        .values(dispatched_action=action, updated_at=utc_now())
+    )
+    if conn is not None:
+        return conn.execute(statement).rowcount == 1
+    with write_connection() as own_conn:
+        return own_conn.execute(statement).rowcount == 1

--- a/timeline_store.py
+++ b/timeline_store.py
@@ -113,3 +113,44 @@ def delete_item(item_id: str) -> bool:
     with write_connection() as conn:
         result = conn.execute(delete(timeline_items).where(timeline_items.c.id == item_id))
         return result.rowcount > 0
+
+
+def claim_action(item_id: str, action: str) -> bool:
+    """Claim this card's one dispatch, atomically. True only for the winner.
+
+    Approval is single-shot: a card carries an action to a member exactly
+    once, or a human double-clicking -- or two surfaces, or a retried
+    request -- executes the same trade more than once. Validating that the
+    card *offers* an action does not give that, because every concurrent
+    caller passes the same validation.
+
+    The guarantee comes from the database rather than from a check in the
+    handler: a single UPDATE ... WHERE dispatched_action = '' can only
+    succeed for one caller, whatever the interleaving, and it holds across
+    processes -- which matters because several timeline-server replicas may
+    serve the same card.
+    """
+    with write_connection() as conn:
+        result = conn.execute(
+            update(timeline_items)
+            .where(timeline_items.c.id == item_id)
+            .where(timeline_items.c.dispatched_action == "")
+            .values(dispatched_action=action, updated_at=utc_now())
+        )
+        return result.rowcount == 1
+
+
+def release_action_claim(item_id: str) -> None:
+    """Undo a claim whose dispatch never happened.
+
+    Dispatch can fail after the claim is taken (the A2A write throws). Left
+    alone, that card would be permanently unapprovable -- terminal without
+    anything having run. Releasing keeps a failed approval retryable, which
+    is the same rule the dispatcher already follows for failed execution.
+    """
+    with write_connection() as conn:
+        conn.execute(
+            update(timeline_items)
+            .where(timeline_items.c.id == item_id)
+            .values(dispatched_action="")
+        )

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,209 @@
+/* MyXstack approval timeline.
+ *
+ * Deliberately dependency-free and build-free: this is a Python repo run
+ * via `make run` / docker compose, and the block set it renders is small
+ * and closed. If this file outgrows a few hundred lines, that is the
+ * signal to reach for a real frontend build rather than to keep growing
+ * it by hand.
+ */
+
+const POLL_MS = 5000;
+
+const feedEl = document.getElementById("feed");
+const statusEl = document.getElementById("status");
+const tokenEl = document.getElementById("token");
+const userEl = document.getElementById("user-id");
+
+// Kept in localStorage so the token is never baked into the served file.
+tokenEl.value = localStorage.getItem("myxstack.token") || "";
+userEl.value = localStorage.getItem("myxstack.user") || "default";
+tokenEl.addEventListener("change", () => {
+  localStorage.setItem("myxstack.token", tokenEl.value.trim());
+  refresh();
+});
+userEl.addEventListener("change", () => {
+  localStorage.setItem("myxstack.user", userEl.value.trim() || "default");
+  refresh();
+});
+document.getElementById("refresh").addEventListener("click", refresh);
+
+function headers() {
+  const token = tokenEl.value.trim();
+  const base = { "Content-Type": "application/json" };
+  return token ? { ...base, Authorization: `Bearer ${token}` } : base;
+}
+
+function setStatus(message, kind = "") {
+  statusEl.textContent = message;
+  statusEl.className = `status ${kind}`;
+}
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined && text !== null) node.textContent = text;
+  return node;
+}
+
+function renderBlock(block) {
+  const wrap = el("div", "block");
+  if (block.label) wrap.appendChild(el("h3", "block-label", block.label));
+
+  switch (block.type) {
+    case "text":
+      wrap.appendChild(el("p", "block-text", block.text || ""));
+      break;
+
+    case "facts": {
+      const dl = el("dl", "facts");
+      (block.facts || []).forEach((fact) => {
+        dl.appendChild(el("dt", null, fact.key));
+        dl.appendChild(el("dd", null, fact.value));
+      });
+      wrap.appendChild(dl);
+      break;
+    }
+
+    case "table": {
+      const scroller = el("div", "table-scroll");
+      const table = el("table");
+      if ((block.columns || []).length) {
+        const head = el("thead");
+        const row = el("tr");
+        block.columns.forEach((col) => row.appendChild(el("th", null, col)));
+        head.appendChild(row);
+        table.appendChild(head);
+      }
+      const body = el("tbody");
+      (block.rows || []).forEach((cells) => {
+        const row = el("tr");
+        cells.forEach((cell) => row.appendChild(el("td", null, cell)));
+        body.appendChild(row);
+      });
+      table.appendChild(body);
+      scroller.appendChild(table);
+      wrap.appendChild(scroller);
+      break;
+    }
+
+    case "links": {
+      const list = el("ul", "links");
+      (block.links || []).forEach((link) => {
+        const item = el("li");
+        const anchor = el("a", null, link.label);
+        anchor.href = link.url;
+        anchor.rel = "noopener noreferrer";
+        anchor.target = "_blank";
+        item.appendChild(anchor);
+        list.appendChild(item);
+      });
+      wrap.appendChild(list);
+      break;
+    }
+
+    default:
+      // An unknown block type must never render as nothing — show the raw
+      // payload so content is visible even on an older UI.
+      wrap.appendChild(el("pre", "block-raw", JSON.stringify(block, null, 2)));
+  }
+  return wrap;
+}
+
+function renderCard(item) {
+  const card = el("article", "card");
+
+  const head = el("header", "card-head");
+  head.appendChild(el("h2", null, item.title || "Untitled"));
+  const meta = el("div", "card-meta");
+  meta.appendChild(el("span", "pill", item.posted_by || "agent"));
+  meta.appendChild(el("span", "pill", item.status || "unread"));
+  if (item.created_at) {
+    meta.appendChild(el("span", "ts", new Date(item.created_at).toLocaleString()));
+  }
+  head.appendChild(meta);
+  card.appendChild(head);
+
+  (item.blocks || []).forEach((block) => card.appendChild(renderBlock(block)));
+
+  const processed = (item.metadata || {}).processed_action;
+  const result = (item.metadata || {}).mcp_result;
+
+  if (result) {
+    const note = el("p", "result", result);
+    card.appendChild(note);
+  }
+
+  const actions = item.actions || [];
+  if (actions.length) {
+    const row = el("div", "actions");
+    actions.forEach((action) => {
+      const button = el("button", `btn ${action.style || "neutral"}`, action.label);
+      if (processed) {
+        // Mirror the dispatcher's terminality rule: once an action has been
+        // processed the card is closed, and offering another button would
+        // promise something the dispatcher will silently skip.
+        button.disabled = true;
+        button.title = `Already processed: ${processed}`;
+      } else {
+        button.addEventListener("click", () => takeAction(item, action));
+      }
+      row.appendChild(button);
+    });
+    card.appendChild(row);
+    if (processed) {
+      card.appendChild(el("p", "closed", `Closed — ${processed} already executed.`));
+    }
+  }
+
+  return card;
+}
+
+async function takeAction(item, action) {
+  if (action.confirm && !window.confirm(action.confirm)) return;
+
+  setStatus(`Sending "${action.label}"…`);
+  try {
+    const response = await fetch(`/v1/timeline/items/${item.id}`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ action_id: action.id }),
+    });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${await response.text()}`);
+    }
+    setStatus(`"${action.label}" sent.`, "ok");
+    refresh();
+  } catch (err) {
+    setStatus(`Failed: ${err.message}`, "err");
+  }
+}
+
+async function refresh() {
+  const userId = userEl.value.trim() || "default";
+  try {
+    const response = await fetch(
+      `/v1/timeline/users/${encodeURIComponent(userId)}/items`,
+      { headers: headers() }
+    );
+    if (response.status === 401) {
+      setStatus("401 — set a valid API token.", "err");
+      return;
+    }
+    if (!response.ok) throw new Error(`${response.status}`);
+
+    const payload = await response.json();
+    feedEl.replaceChildren();
+    const items = payload.items || [];
+    if (!items.length) {
+      feedEl.appendChild(el("p", "empty", "No cards yet."));
+    } else {
+      items.forEach((item) => feedEl.appendChild(renderCard(item)));
+    }
+    setStatus(`${items.length} card(s) — updated ${new Date().toLocaleTimeString()}`);
+  } catch (err) {
+    setStatus(`Could not load timeline: ${err.message}`, "err");
+  }
+}
+
+refresh();
+setInterval(refresh, POLL_MS);

--- a/ui/app.js
+++ b/ui/app.js
@@ -147,7 +147,13 @@ function renderCard(item) {
 
   (item.blocks || []).forEach((block) => card.appendChild(renderBlock(block)));
 
-  const processed = (item.metadata || {}).processed_action;
+  // Two different moments close a card, and the gap between them is where a
+  // second click used to land: `dispatched_action` is set by the API the
+  // instant an action is claimed, `processed_action` only once the dispatcher
+  // has executed it. Treat either as closed so the buttons go dead on
+  // approval rather than one poll later.
+  const dispatched = item.dispatched_action;
+  const processed = (item.metadata || {}).processed_action || dispatched;
   const result = (item.metadata || {}).mcp_result;
 
   if (result) {
@@ -197,6 +203,15 @@ async function takeAction(item, action) {
       headers: headers(),
       body: JSON.stringify({ action_id: action.id }),
     });
+    // 409 is not a failure: the card was already approved — by another
+    // operator, another tab, or an earlier click of this one. Say so plainly
+    // and refresh, so the card redraws as closed instead of leaving a red
+    // error next to a card that is in exactly the intended state.
+    if (response.status === 409) {
+      setStatus("Already actioned — someone got there first.", "ok");
+      refresh();
+      return;
+    }
     if (!response.ok) {
       throw new Error(`${response.status} ${await response.text()}`);
     }

--- a/ui/app.js
+++ b/ui/app.js
@@ -38,6 +38,22 @@ function setStatus(message, kind = "") {
   statusEl.className = `status ${kind}`;
 }
 
+// Mirrors is_safe_url() in cards.py. Only http(s) may reach an anchor's href —
+// a javascript: URL would run in this origin, where the approval token lives.
+function isSafeUrl(value) {
+  if (typeof value !== "string") return false;
+  try {
+    const scheme = new URL(value, window.location.href).protocol;
+    return scheme === "http:" || scheme === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// Cards with a PATCH in flight. Prevents a double-click from sending two
+// competing actions before the first response lands.
+const inFlight = new Set();
+
 function el(tag, className, text) {
   const node = document.createElement(tag);
   if (className) node.className = className;
@@ -90,11 +106,17 @@ function renderBlock(block) {
       const list = el("ul", "links");
       (block.links || []).forEach((link) => {
         const item = el("li");
-        const anchor = el("a", null, link.label);
-        anchor.href = link.url;
-        anchor.rel = "noopener noreferrer";
-        anchor.target = "_blank";
-        item.appendChild(anchor);
+        if (isSafeUrl(link.url)) {
+          const anchor = el("a", null, link.label);
+          anchor.href = link.url;
+          anchor.rel = "noopener noreferrer";
+          anchor.target = "_blank";
+          item.appendChild(anchor);
+        } else {
+          // Defence in depth: the API rejects these too, but a stored card
+          // predating that validation must never become a live href.
+          item.appendChild(el("span", null, `${link.label} (unsafe link removed)`));
+        }
         list.appendChild(item);
       });
       wrap.appendChild(list);
@@ -159,8 +181,15 @@ function renderCard(item) {
 }
 
 async function takeAction(item, action) {
+  // Reject before sending, not after: a second PATCH would queue a competing
+  // action that the dispatcher then has to discard as already-processed.
+  if (inFlight.has(item.id)) {
+    setStatus("An action on this card is already in flight.", "err");
+    return;
+  }
   if (action.confirm && !window.confirm(action.confirm)) return;
 
+  inFlight.add(item.id);
   setStatus(`Sending "${action.label}"…`);
   try {
     const response = await fetch(`/v1/timeline/items/${item.id}`, {
@@ -175,6 +204,8 @@ async function takeAction(item, action) {
     refresh();
   } catch (err) {
     setStatus(`Failed: ${err.message}`, "err");
+  } finally {
+    inFlight.delete(item.id);
   }
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MyXstack — Approval Timeline</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header class="bar">
+      <h1>MyXstack</h1>
+      <div class="bar-controls">
+        <label class="field">
+          <span>User</span>
+          <input id="user-id" type="text" value="default" spellcheck="false" />
+        </label>
+        <label class="field">
+          <span>API token</span>
+          <input
+            id="token"
+            type="password"
+            placeholder="unset = open server"
+            spellcheck="false"
+            autocomplete="off"
+          />
+        </label>
+        <button id="refresh" type="button">Refresh</button>
+      </div>
+    </header>
+
+    <p id="status" class="status" role="status"></p>
+    <main id="feed" class="feed"></main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,0 +1,271 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --surface: #ffffff;
+  --border: #d9dde3;
+  --text: #14181f;
+  --muted: #5c6672;
+  --accent: #1d6ef2;
+  --danger: #c8362b;
+  --ok: #1c7a4a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e1116;
+    --surface: #161b22;
+    --border: #2a313b;
+    --text: #e6e9ee;
+    --muted: #9aa4b1;
+    --accent: #4c8dff;
+    --danger: #f0705f;
+    --ok: #56c98c;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 14px 20px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.bar h1 {
+  margin: 0;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+}
+
+.bar-controls {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.field input {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  min-width: 170px;
+}
+
+.status {
+  margin: 0;
+  padding: 8px 20px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.status.ok {
+  color: var(--ok);
+}
+.status.err {
+  color: var(--danger);
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 6px 20px 48px;
+  max-width: 820px;
+}
+
+.empty {
+  color: var(--muted);
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+
+.card-head h2 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.card-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.pill {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+}
+
+.ts {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.block + .block {
+  margin-top: 14px;
+}
+
+.block-label {
+  margin: 0 0 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.block-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.block-raw {
+  margin: 0;
+  overflow-x: auto;
+  font-size: 12px;
+  background: var(--bg);
+  padding: 8px;
+  border-radius: 6px;
+}
+
+.facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 3px 14px;
+  margin: 0;
+}
+
+.facts dt {
+  color: var(--muted);
+}
+.facts dd {
+  margin: 0;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 14px;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.links {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.links a {
+  color: var(--accent);
+}
+
+.result {
+  margin: 14px 0 0;
+  padding: 9px 11px;
+  background: var(--bg);
+  border-left: 3px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+  white-space: pre-wrap;
+}
+
+.actions {
+  display: flex;
+  gap: 9px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  font: inherit;
+  font-size: 14px;
+  padding: 7px 15px;
+  border-radius: 7px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--muted);
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.btn.danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.closed {
+  margin: 9px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+}

--- a/ui/style.css
+++ b/ui/style.css
@@ -254,6 +254,15 @@ th {
   color: #fff;
 }
 
+/* The dark-mode accent is light enough that white text falls under 4.5:1.
+   Flip to dark text on it instead of darkening the accent, which would hurt
+   the link colour that shares the token. */
+@media (prefers-color-scheme: dark) {
+  .btn.primary {
+    color: var(--bg);
+  }
+}
+
 .btn.danger {
   color: var(--danger);
   border-color: var(--danger);


### PR DESCRIPTION
## Why

This started as an evaluation of [CopilotKit/OpenTag](https://github.com/CopilotKit/OpenTag) — whether we already have something like it, or whether adding it would create value.

**Conclusion: don't adopt it.** OpenTag is a *delivery surface* (a LangGraph agent served over AG-UI into Slack/Teams via the Channels SDK). It solves ingress, and our ingress is already solved and different — X mentions through `listener.py` → `agents/router.py`. Adopting it would put a hosted third party (CopilotKit Intelligence, `INTELLIGENCE_API_KEY`) in the path that authorizes agent actions, and add Node 22 + pnpm + uv + LangGraph as a fifth runtime.

But investigating it surfaced a real gap. The approval gate — the whole point of putting action behind agents on X — had **no interface at all**, and did not actually gate:

- `a2a_store.py` registered a `timeline-ui` agent whose client did not exist. Zero frontend files in the repo.
- `PATCH /v1/timeline/items/{id}` had **no authentication**. Anyone who could reach :8080 could approve anything.
- The same action **dispatched once per request**, so a double-click executed the trade twice.
- The presentation contract was `body: str` + `actions: List[str]`, so every member hand-concatenated its output into one blob.

This PR closes that gap. Two ideas are borrowed from OpenTag — a typed renderable card schema and a structured human-in-the-loop confirmation — with none of its dependencies.

This is deliberately **not** trade-specific: `@Tradedesk` is one example member, and the card contract is generic across research, shopping, ticker lookups, and members not yet written.

## What changed

### Typed cards — `cards.py`

Cards carry `blocks` (`text`, `facts`, `table`, `links`) instead of one concatenated string. Actions are typed too — `{id, label, style, confirm}`.

Two compatibility rules, both load-bearing:

1. **`body` is never dropped.** It is derived from blocks when not supplied, so the dispatcher, existing tests, and plain curl keep working.
2. **`action` on the wire keeps carrying the human *label*.** Members match on labels — `shopping.py` matches `startswith("approve")` against `"Approve Purchase"`. A surface posts `action_id` and the server resolves it before dispatch, so member code and `mcp_dispatcher.py` are untouched.

Legacy cards upgrade in memory on read. An `action_id` a card doesn't offer is a 400. So is an **ambiguous** one: stored cards can carry duplicate ids, and resolving to the first match would execute a different action than the human clicked.

### Approval is single-shot, and the claim can't be lost

Approving used to dispatch on every PATCH. Eight concurrent approvals of one trade proposal produced **eight dispatch messages, 5/5 trials**. Validating that the card *offers* the action never prevented it — every concurrent caller passes that same check — and `metadata.processed_action` isn't a guard either, since the dispatcher writes it afterwards in another process.

`timeline_items` gains `dispatched_action`, claimed with a conditional `UPDATE … WHERE dispatched_action = ''`. One caller wins whatever the interleaving, across processes.

**The claim and the dispatch share one transaction.** A claim in its own transaction converts a duplicate-dispatch bug into a lost-dispatch one: kill the process in the gap and the card is claimed with nothing sent — terminal, unrecoverable, silent. Lost approvals are the harder failure to notice. Sharing the transaction means a crash rolls back both and the card stays approvable; it also removes the need for any release path.

After the fix: one 200, seven 409s, one dispatch — 5/5 trials.

### Approval UI — `ui/`, served at `/ui`

Dependency-free and build-free. Renders each block type. A card closes on *either* `dispatched_action` (set the instant it's claimed) or `metadata.processed_action` (set once executed) — the gap between them is the window a second click lands in. A 409 reads as "already actioned", not an error.

### Authentication

`TIMELINE_API_TOKEN` guards all `/v1` routes; `/health` stays open for probes. CORS off by default. The check runs at **import time**, because `main.py` does `from timeline_server import app` — so `uvicorn main:app`, the Railway path, never calls `timeline_server.main()`.

With a deployment marker present (`RAILWAY_SERVICE_NAME`, `RAILWAY_ENVIRONMENT`, `KUBERNETES_SERVICE_HOST`) an empty token is fatal; locally it warns.

> **Open question, deliberately not decided here.** That detection is a heuristic and only covers Railway and Kubernetes. A VPS, Fly, Render, or `docker compose` on a public host sets none of them, so an empty token there warns instead of refusing and the approval API is anonymous. Closing it means inverting the default — always fatal, opt out explicitly for local — which trades a silent gap for a startup error on every fresh checkout. That's a call about contributor experience rather than a defect, so it is documented in `README.md`, `env.example`, and the `enforce_token_policy` docstring and left for a maintainer.

### Merge with the SQL persistence layer (#125), and three boot races

#125 replaced the JSON stores with SQLAlchemy mid-flight. Kept its `timeline_store.py` and ported card typing onto it; took its `a2a_store.py` and workflow; kept `store_lock.py` for the paper-trade ledger only.

`storage_db.py` gains `blocks`, `schema_version`, `dispatched_action`. `create_all()` leaves an existing table alone, so a database created between #125 and this merge would fail every read; `_add_missing_columns()` adds them in place, with nullability and defaults read off the `Column` rather than hardcoded.

Four services share one database, and each of these was a reflect-then-write with no lock between the halves. Found by running the topology, not reading the code:

| Where | Symptom | Reproduced |
|---|---|---|
| `_add_missing_columns` | duplicate column on upgrade | 2 of 4 services dead |
| `create_all` | unique violation on Postgres' own catalog | 2–3 of 4 dead, every run |
| `_ensure_default_agents` | duplicate key on `a2a_agents_pkey` | 3 of 4 dead |

**Two predate this branch** — they came with #125, and are fixed here because this PR documents and relies on the four-service Postgres topology. Reviewers may reasonably want them split out; they're self-contained. **SQLite hides all three** (writers serialize under `BEGIN IMMEDIATE`), which is why the suite stayed green.

### Two more silent failures

- `migrate_json_to_sql.py` read a corrupt store as `{}` and printed `Migration complete: inserted=0`. An operator deletes the JSON store on the strength of that. Decode errors and unparsable timestamps now fail; re-runs no longer rewrite `created_at`.
- `main.py` started the listener only for `RAILWAY_SERVICE_NAME=x-listener`, while `docs/DEPLOYMENT.md` told operators to name it `listener`. Under Railway's default `uvicorn main:app` that container came up healthy, answered `/health`, and polled nothing. Both names now work, an unrecognised name warns, and the docs say the name is load-bearing.

### Incidental

The Dockerfile copied neither `agents/` nor `ui/`, so `listener` and `mcp-dispatcher` **could not have started in Docker**. #125 fixed `agents/`; this adds `ui/`.

## Preserved behaviour

This PR's entire diff to `mcp_dispatcher.py` is adding `headers=timeline_headers()` to five HTTP calls — its decision logic is byte-for-byte unchanged. Its `PATCH` sends only `{"metadata": …}`, so the claim cannot 409 the dispatcher's own `processed_action` write.

## Testing

**24 → 98**, green on SQLite, Postgres 16, and with a Kubernetes marker set.

### Every guard was checked by disabling it

A test that would pass anyway is worse than no test. That caught three bad tests before they were committed:

- The first-deploy test was **thread**-based and passed with the fixes removed — threads share `_ENGINE_LOCK`, `_SEED_LOCK`, and the cached engine, serializing the very steps under test. Rewritten to four real processes, it fails 3/3 without them.
- The column-upgrade test hardcoded SQLite, so it would have passed under the postgres job without running the Postgres DDL (`JSONB`, `NOT NULL` applied to existing rows).
- The upgrade tests' "schema before this PR" was duplicated inline; it now comes from one helper, and one named column set with an assertion that catches a rename.

Also fixed: the client fixture never cleared deployment markers, so `enforce_token_policy` made **every test error on a Kubernetes CI runner** (verified: 24 errors); and `test_timeline_startup` isolated the old JSON paths, which isolate nothing now — those tests ran against `~/.xmcp/xmcp.db` on the developer's machine.

### On the CI gate

`agent-ci.yml` was green for this repo's entire history while running **zero** Python tests: it detects the framework from `package.json` (the `src/` TypeScript agent) and never reaches the Python branch, which is `pytest … 2>/dev/null || true` under `continue-on-error` anyway.

The replacement was proven in both directions: `5a445df` success → `c1e45d2` **failure** ([run](https://github.com/groupthinking/MyXstack/actions/runs/31207902018/job/92963387018)) → `946315e` success. Those proof commits sit in this branch's history, so the checks tab shows one red run; squash-merging collapses them.

Worth stating plainly: **CI was green through every defect above.** The suite boots one process; the races need four, and the duplicate dispatch needed concurrent requests. Green here is weaker evidence than it looks.

## Follow-ups (deliberately out of scope)

- **`mcp_dispatcher` has no tests.** Four safety invariants gate whether an approved action executes, and nothing exercises them — the logic sits in a `while True` loop no test can enter. Extracting it is a refactor of the component that executes trades and does not belong at the end of this PR.
- The token-detection heuristic above.
- AG-UI protocol conformance; per-user auth; Alembic; multi-MCP-server support.
- Deleting the stale `src/` TypeScript agent and the three stale docs.
- The repo has both `.env.example` and `env.example` with different contents — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaXnPGMwQkq1ANhaag1voU