### PR TITLE
Register Hermes as the untagged mention fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Mentions are routed to a **team of @handle-addressable members** (see [docs/AGEN
 @MyXstack @Research why is $NVDA down? → Grok research brief on the timeline
 @MyXstack @Shopping shoes under $150   → product picks, purchase approval-gated
 @MyXstack @TickerBot $BTC              → deterministic cashtag lookup (API bot)
+@MyXstack stand up a 48-hour probe     → Hermes owns the goal and briefs it
 ```
 
-Members are classified as **interactive agents** (`kind: agent` — conversational, LLM-backed, can delegate over A2A) or **API bots** (`kind: bot` — deterministic input → function → output). Untagged mentions fall back to the original generic Grok behavior.
+Members are classified as **orchestrator** (`kind: orchestrator` — Hermes; owns untagged goals, routes vertical jobs, never does the specialist's job), **interactive agents** (`kind: agent` — conversational, LLM-backed, can delegate over A2A) or **API bots** (`kind: bot` — deterministic input → function → output). Untagged mentions go to **Hermes**, not a generic Grok dump. Tagged specialists still win when present.
 
 There is also an alternative **TypeScript standalone agent** in `src/` that combines listening + MCP server in a single process (see [TypeScript Agent](#typescript-agent) below).
 

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,7 +1,9 @@
 """Core types for the MyXstack agent team.
 
-Team members are classified into two kinds:
+Team members are classified into three kinds:
 
+- kind="orchestrator" (Hermes): owns the goal, routes work, never does
+  the specialist's job. Untagged mentions land here.
 - kind="agent" (interactive agent): conversational, LLM-backed via Grok,
   may run its own sub-steps, delegate to other members over A2A, and
   propose actions that require human approval on the timeline.
@@ -19,6 +21,7 @@ from cards import is_safe_url
 
 KIND_AGENT = "agent"
 KIND_BOT = "bot"
+KIND_ORCHESTRATOR = "orchestrator"
 
 
 @dataclass
@@ -53,6 +56,7 @@ class AgentProfile:
     description: str
     kind: str = KIND_AGENT
     tags: List[str] = field(default_factory=list)
+    fallback: bool = False
 
 
 class TeamMember:

--- a/agents/registry.py
+++ b/agents/registry.py
@@ -13,13 +13,23 @@ from agents.router import find_target
 
 def build_team() -> List[TeamMember]:
     from agents.team.general import GeneralAgent
+    from agents.team.hermes import HermesAgent
     from agents.team.research import ResearchAgent
     from agents.team.shopping import ShoppingAgent
     from agents.team.tickerbot import TickerBot
     from agents.team.tradedesk import TradeDeskAgent
 
-    # GeneralAgent must stay last: it is the fallback when no handle matches.
-    return [TradeDeskAgent(), ShoppingAgent(), ResearchAgent(), TickerBot(), GeneralAgent()]
+    # Hermes is the untagged fallback and is also @handle-addressable.
+    # GeneralAgent stays on the roster only so pre-Hermes cards with
+    # agent_id "x-agent" still have an owner for execute_action.
+    return [
+        HermesAgent(),
+        TradeDeskAgent(),
+        ShoppingAgent(),
+        ResearchAgent(),
+        TickerBot(),
+        GeneralAgent(),
+    ]
 
 
 _TEAM: Optional[List[TeamMember]] = None
@@ -36,13 +46,19 @@ def get_team() -> List[TeamMember]:
 
 
 def route_mention(mention: MentionContext) -> TeamMember:
-    """Route to the earliest-tagged member; fall back to the member with an
-    empty handle (the general agent), regardless of roster order."""
+    """Route to the earliest-tagged member; otherwise the fallback member.
+
+    Fallback is Hermes (profile.fallback=True), not a generic Grok dump
+    and not "whoever has an empty handle".
+    """
     team = get_team()
     target = find_target(mention.text, team)
     if target:
         return target
-    return next(m for m in team if not m.profile.handle)
+    for member in team:
+        if member.profile.fallback:
+            return member
+    raise RuntimeError("No fallback member registered")
 
 
 def find_member(agent_id: Optional[str]) -> Optional[TeamMember]:

--- a/agents/router.py
+++ b/agents/router.py
@@ -12,8 +12,8 @@ def find_target(text: str, team: List[TeamMember]) -> Optional[TeamMember]:
     Matching is case-insensitive and word-bounded, so @Tradedesk matches
     "@tradedesk $TSLA buy" but not "@TradedeskFanClub". When several
     members are tagged, the one tagged first wins (user intent, not roster
-    order). Members with an empty handle (the fallback agent) are never
-    matched here.
+    order). Members with an empty handle are never matched here; untagged
+    mentions are routed to the fallback member (Hermes) by route_mention.
     """
     lowered = text.lower()
     best_member: Optional[TeamMember] = None

--- a/agents/team/general.py
+++ b/agents/team/general.py
@@ -1,8 +1,8 @@
-"""General agent — the fallback when no team member is tagged.
+"""Legacy general agent — owner of pre-Hermes `x-agent` cards.
 
-Preserves the original listener behavior: send the whole mention to Grok
-with MCP tools and reply with whatever it produces, logging a card with
-Approve/Reject/Snooze follow-up actions.
+New untagged mentions go to Hermes, not here. This member stays on the
+roster so the dispatcher can still execute Approve/Reject/Snooze on cards
+created before Hermes became the fallback.
 """
 
 from typing import Any, Dict, Optional

--- a/agents/team/hermes.py
+++ b/agents/team/hermes.py
@@ -1,0 +1,175 @@
+"""@Hermes — orchestrator. Owns the goal. Never does the specialist's job.
+
+Untagged mentions land here. Tagged specialists still win when present.
+
+Usage on X:
+  @MyXstack why is $NVDA down?          → Hermes owns it, hands to @Research
+  @MyXstack $TSLA buy 100               → Hermes owns it, hands to @Tradedesk
+  @MyXstack stand up a 48-hour probe    → Hermes briefs the goal
+  @MyXstack @Hermes …                   → same member, tagged explicitly
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, Optional
+
+from agents.base import (
+    KIND_ORCHESTRATOR,
+    AgentProfile,
+    AgentReply,
+    MentionContext,
+    TeamMember,
+    build_card,
+    facts_block,
+    grok_chat,
+    send_a2a_message,
+    text_block,
+    truncate_for_reply,
+    wrap_untrusted,
+)
+from agents.team.tradedesk import parse_trade_command
+
+_SHOPPING = re.compile(
+    r"\b(find(?:\s+me)?|shop(?:ping)?|buy me|purchase|under\s+\$)\b",
+    re.IGNORECASE,
+)
+_QUESTION = re.compile(
+    r"\b(why|what(?:'s|s)?|how|who|when|where|explain|brief|research)\b",
+    re.IGNORECASE,
+)
+_CASHTAG = re.compile(r"\$[A-Za-z]{1,10}\b")
+
+ORCHESTRATOR_PROMPT = (
+    "You are Hermes, orchestrator of MyXstack. You own the goal. "
+    "You never do the specialist's job, invent citations, or answer the "
+    "question yourself.\n"
+    "Specialists: @Research (live briefs), @Tradedesk (paper-trade proposals), "
+    "@Shopping (product picks, approval-gated), @TickerBot (cashtag lookup).\n"
+    "Decompose the inbound goal into 3-7 operational units. Each unit names "
+    "an owner, the work, and a definition of done. Side-effects wait on a "
+    "timeline card. Closed loops only.\n"
+    "Return plain text in this shape:\n"
+    "Goal: …\n"
+    "Units:\n"
+    "1. owner — work — done: …\n"
+    "Side-effect: none | named gate\n"
+    "Stop: …\n\n"
+)
+
+
+def pick_owner(text: str) -> Optional[str]:
+    """Return a specialist id when the mention is already a vertical job.
+
+    None means Hermes keeps the goal and briefs it. Deterministic — no LLM.
+    Order is the contract: a parsed trade beats a shopping phrase, a
+    question beats a bare cashtag.
+    """
+    if parse_trade_command(text):
+        return "tradedesk"
+    if _SHOPPING.search(text):
+        return "shopping"
+    if _QUESTION.search(text):
+        return "research"
+    if _CASHTAG.search(text):
+        return "tickerbot"
+    return None
+
+
+class HermesAgent(TeamMember):
+    def __init__(self):
+        super().__init__(
+            AgentProfile(
+                id="hermes",
+                handle=os.getenv("HERMES_HANDLE", "Hermes"),
+                name="Hermes",
+                description=(
+                    "Owns untagged goals. Routes vertical jobs to specialists. "
+                    "Never answers as a generic Grok dump."
+                ),
+                kind=KIND_ORCHESTRATOR,
+                tags=["command", "orchestrator"],
+                fallback=True,
+            )
+        )
+
+    def handle_mention(self, mention: MentionContext) -> AgentReply:
+        owner_id = pick_owner(mention.text)
+        if owner_id:
+            handed = self._handoff(mention, owner_id)
+            if handed:
+                return handed
+        return self._brief(mention)
+
+    def execute_action(self, item: Dict[str, Any], action: str) -> Optional[str]:
+        metadata = item.get("metadata") or {}
+        if metadata.get("agent_id") != self.profile.id:
+            return None
+        return (
+            f"Hermes briefs are informational. Action '{action}' did not "
+            "execute a side-effect."
+        )
+
+    def _handoff(self, mention: MentionContext, owner_id: str) -> Optional[AgentReply]:
+        from agents.registry import find_member
+
+        owner = find_member(owner_id)
+        if owner is None or owner.profile.id == self.profile.id:
+            return None
+        send_a2a_message(
+            from_agent=self.profile.id,
+            to=owner.profile.id,
+            message_type="handoff",
+            content=mention.text,
+            metadata={
+                "mention_id": mention.mention_id,
+                "reason": "untagged vertical job",
+            },
+        )
+        reply = owner.handle_mention(mention)
+        if reply.card:
+            meta = dict(reply.card.get("metadata") or {})
+            meta["routed_by"] = self.profile.id
+            reply.card["metadata"] = meta
+        handle = owner.profile.handle or owner.profile.id
+        prefix = f"Hermes → @{handle}. "
+        reply.text = truncate_for_reply(prefix + reply.text)
+        return reply
+
+    def _brief(self, mention: MentionContext) -> AgentReply:
+        plan = grok_chat(
+            ORCHESTRATOR_PROMPT + wrap_untrusted(mention.text)
+        )
+        if not plan:
+            plan = (
+                "Grok is offline. Goal is owned by Hermes. No specialist "
+                "assigned. No side-effect proposed."
+            )
+        card = build_card(
+            title="Hermes brief",
+            blocks=[
+                facts_block(
+                    {
+                        "Owner": "Hermes",
+                        "Route": "captain",
+                        "Side-effect": "none",
+                    },
+                    label="Intake",
+                ),
+                text_block(mention.text, label="Goal"),
+                text_block(plan, label="Units"),
+            ],
+            metadata={
+                "agent_id": self.profile.id,
+                "action_type": "brief",
+                "mention_id": mention.mention_id,
+                "author_id": mention.author_id,
+                "conversation_id": mention.conversation_id,
+            },
+        )
+        reply = truncate_for_reply(
+            "Hermes has the goal. Units on your timeline.",
+            suffix="… Full brief on your timeline.",
+        )
+        return AgentReply(text=reply, card=card)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,14 +1,16 @@
 # Agent Team
 
 MyXstack runs a **team of @handle-addressable members** on top of the A2A
-(agent-to-agent) layer. Tag a member in any mention and the listener routes
-the request to it:
+(agent-to-agent) layer. Tag a member in any mention and the listener routes the request to it.
+Untagged mentions go to **Hermes**.
 
 ```text
 @MyXstack @Tradedesk $TSLA buy 100
 @MyXstack @Research what's driving the $NVDA selloff?
 @MyXstack @Shopping find trail running shoes under $150
 @MyXstack @TickerBot $BTC
+@MyXstack stand up a 48-hour probe
+@MyXstack @Hermes own this goal
 ```
 
 ## Classification: interactive agents vs API bots
@@ -18,6 +20,7 @@ registry at `GET /v1/a2a/agents`):
 
 | Kind | What it is | Traits |
 |------|------------|--------|
+| `orchestrator` | Captain. Owns the goal. | Routes work, reads the roster, never does the specialist's job. Untagged mentions land here. |
 | `agent` (interactive agent) | Conversational, LLM-backed member | Reasons with Grok + MCP tools, can converse, run sub-steps, delegate to other members over A2A, and propose actions gated on human approval |
 | `bot` (API bot) | Deterministic function executor | Input → function → output. No LLM, no autonomy, instant and predictable |
 
@@ -25,13 +28,14 @@ registry at `GET /v1/a2a/agents`):
 
 | Handle | ID | Kind | What it does |
 |--------|----|------|--------------|
+| `@Hermes` | `hermes` | orchestrator | Owns untagged goals. Hands a vertical job to the matching specialist. Otherwise files a captain brief (units, owners, stop). Never answers as a generic Grok dump. |
 | `@Tradedesk` | `tradedesk` | agent | Parses `$TICKER buy/sell [qty]`, logs a **trade proposal** to the approval timeline. On Approve, executes via the **paper broker** (simulated fills in `~/.xmcp/paper_trades.json`). No live orders — a real broker is a pluggable adapter with the same `execute()` interface. |
 | `@Shopping` | `shopping` | agent | Researches product picks with Grok; purchases are approval-gated intents (no payment executor is wired in by default). |
 | `@Research` | `research` | agent | Answers questions using Grok + MCP tools for live X context; posts a short reply and files the full brief on the timeline. |
 | `@TickerBot` | `tickerbot` | bot | Deterministic cashtag lookup — returns live-search links for each `$TICKER`. Reference implementation of the `bot` kind. |
-| *(fallback)* | `x-agent` | agent | Original generic behavior when no member is tagged. |
+| *(legacy)* | `x-agent` | agent | Owner of pre-Hermes cards only. New untagged mentions do not land here. |
 
-Handles are configurable via `TRADEDESK_HANDLE`, `RESEARCH_HANDLE`,
+Handles are configurable via `HERMES_HANDLE`, `TRADEDESK_HANDLE`, `RESEARCH_HANDLE`,
 `SHOPPING_HANDLE`, `TICKERBOT_HANDLE` in `.env`.
 
 ## How a request flows
@@ -62,8 +66,8 @@ interactive agent can drive its own sub-agents and bots this way.
    - set an `AgentProfile` with a unique `id`, a `handle`, and a `kind`
    - implement `handle_mention()` → `AgentReply(text, card=None)`
    - implement `execute_action()` if your cards have Approve/Reject actions
-2. Add it to `build_team()` in `agents/registry.py` (before the fallback
-   `GeneralAgent`).
+2. Add it to `build_team()` in `agents/registry.py`. Untagged mentions always
+   go to the member with `fallback=True` (Hermes). Do not add a second fallback.
 3. Done — routing, X replies, timeline cards, and dispatcher callbacks are
    handled by the framework.
 

--- a/env.example
+++ b/env.example
@@ -87,6 +87,7 @@ X_API_DEBUG=1
 # Agent Team (agents/ — @handle-routed members)
 # ─────────────────────────────────────────────
 # @handles users tag in mentions (without the @)
+HERMES_HANDLE=Hermes
 TRADEDESK_HANDLE=Tradedesk
 RESEARCH_HANDLE=Research
 SHOPPING_HANDLE=Shopping

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -1,0 +1,81 @@
+from agents.base import AgentReply, MentionContext
+from agents.registry import build_team, route_mention
+from agents.team.hermes import HermesAgent, pick_owner
+
+
+def test_pick_owner_trade():
+    assert pick_owner("@MyXstack $TSLA buy 100") == "tradedesk"
+    assert pick_owner("buy $NVDA 5") == "tradedesk"
+
+
+def test_pick_owner_shopping():
+    assert pick_owner("@MyXstack find trail running shoes under $150") == "shopping"
+
+
+def test_pick_owner_research_question():
+    assert pick_owner("@MyXstack why is $NVDA down?") == "research"
+
+
+def test_pick_owner_bare_cashtag():
+    assert pick_owner("@MyXstack $BTC") == "tickerbot"
+
+
+def test_pick_owner_goal_stays_with_hermes():
+    assert pick_owner("@MyXstack stand up a 48-hour LinkedIn probe") is None
+    assert pick_owner("@MyXstack open a pod for Northwater") is None
+
+
+def test_untagged_mention_routes_to_hermes():
+    member = route_mention(MentionContext(text="@MyXstack what's the weather?"))
+    assert member.profile.id == "hermes"
+    assert member.profile.fallback is True
+    assert member.profile.kind == "orchestrator"
+
+
+def test_tagged_hermes_routes_to_hermes():
+    member = route_mention(MentionContext(text="@MyXstack @Hermes own this goal"))
+    assert member.profile.id == "hermes"
+
+
+def test_tagged_specialist_still_wins():
+    member = route_mention(MentionContext(text="@MyXstack @Research why is $NVDA down?"))
+    assert member.profile.id == "research"
+
+
+def test_exactly_one_fallback():
+    fallbacks = [m.profile.id for m in build_team() if m.profile.fallback]
+    assert fallbacks == ["hermes"]
+
+
+def test_hermes_brief_is_not_a_generic_dump(monkeypatch):
+    captured = {}
+
+    def fake_grok(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "Goal: probe\nUnits:\n1. Harper — landscape — done: cited brief"
+
+    monkeypatch.setattr("agents.team.hermes.grok_chat", fake_grok)
+    reply = HermesAgent().handle_mention(
+        MentionContext(text="@MyXstack stand up a 48-hour LinkedIn probe", mention_id=9)
+    )
+    assert isinstance(reply, AgentReply)
+    assert "Hermes has the goal" in reply.text
+    assert reply.card is not None
+    assert reply.card["metadata"]["agent_id"] == "hermes"
+    assert reply.card["actions"] == []
+    assert "autonomous X agent bot" not in captured["prompt"]
+    assert "never do the specialist" in captured["prompt"].lower()
+
+
+def test_hermes_handoff_preserves_specialist_owner(monkeypatch):
+    monkeypatch.setattr("agents.team.hermes.send_a2a_message", lambda *a, **k: True)
+    monkeypatch.setenv("TRADEDESK_USE_GROK", "0")
+    # Rebuild after env so the TradeDesk constructed inside get_team is stale;
+    # call handle_mention on a fresh Hermes against the live team.
+    reply = HermesAgent().handle_mention(
+        MentionContext(text="@MyXstack $TSLA buy 100", mention_id=3)
+    )
+    assert reply.card is not None
+    assert reply.card["metadata"]["agent_id"] == "tradedesk"
+    assert reply.card["metadata"]["routed_by"] == "hermes"
+    assert reply.text.startswith("Hermes → @")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -19,9 +19,10 @@ def test_route_requires_word_boundary():
     assert member is None
 
 
-def test_route_falls_back_to_general_agent():
+def test_route_falls_back_to_hermes():
     member = route_mention(MentionContext(text="@MyXstack what's the weather?"))
-    assert member.profile.id == "x-agent"
+    assert member.profile.id == "hermes"
+    assert member.profile.fallback is True
 
 
 def test_route_to_bot():
@@ -32,10 +33,12 @@ def test_route_to_bot():
 
 def test_team_classification():
     kinds = {m.profile.id: m.profile.kind for m in get_team()}
+    assert kinds["hermes"] == "orchestrator"
     assert kinds["tradedesk"] == "agent"
     assert kinds["research"] == "agent"
     assert kinds["shopping"] == "agent"
     assert kinds["tickerbot"] == "bot"
+    assert kinds["x-agent"] == "agent"
 
 
 def test_multi_handle_routes_to_earliest_tag():
@@ -48,5 +51,6 @@ def test_multi_handle_routes_to_earliest_tag():
 
 def test_find_member():
     assert find_member("tradedesk").profile.name == "Trade Desk"
+    assert find_member("hermes").profile.name == "Hermes"
     assert find_member("nope") is None
     assert find_member(None) is None


### PR DESCRIPTION
Item 1 of the OS spec against the live Python service.

**What changed**
- Hermes is a real team member (`kind: orchestrator`, handle `@Hermes`, `fallback=True`).
- Untagged mentions (`@MyXstack …`) route to Hermes, not the generic Grok dump (`x-agent`).
- Tagged specialists still win (`@Research`, `@Tradedesk`, …).
- If the untagged text is already a vertical job, Hermes hands it off (trade → Tradedesk, question → Research, shopping phrase → Shopping, bare cashtag → TickerBot) and stamps `routed_by: hermes` on the specialist's card.
- Otherwise Hermes files a captain brief (units / owners / stop). No Approve/Reject on that card — it is not a side-effect.
- `x-agent` stays on the roster only so pre-Hermes cards still have an owner for `execute_action`.

**Verify**
```text
pytest tests/test_router.py tests/test_hermes.py -q
```
Full suite: 109 passed locally.

The OS console already treats captain as the untagged default; this makes the live listener match that spec.